### PR TITLE
Test/follow/#15 follow service test

### DIFF
--- a/src/main/java/com/goorm/clonestagram/follow/controller/FollowController.java
+++ b/src/main/java/com/goorm/clonestagram/follow/controller/FollowController.java
@@ -14,38 +14,24 @@ public class FollowController {
 
     private final FollowService followService;
 
-    /**
-     * 팔로워 목록 조회
-     * @param userId 팔로워 목록을 조회할 사용자 ID
-     * @return 팔로워 목록
-     */
-    @GetMapping("/{userId}/profile/followers")
-    public ResponseEntity<List<FollowDto>> getFollowers(@PathVariable Long userId) {
-        List<FollowDto> followers = followService.getFollowerList(userId);
-        return ResponseEntity.ok(followers);
-    }
-
-    /**
-     * 팔로잉 목록 조회
-     * @param userId 팔로잉 목록을 조회할 사용자 ID
-     * @return 팔로잉 목록
-     */
-    @GetMapping("/{userId}/profile/following")
-    public ResponseEntity<List<FollowDto>> getFollowing(@PathVariable Long userId) {
-        List<FollowDto> following = followService.getFollowingList(userId);
-        return ResponseEntity.ok(following);
-    }
-
-    /**
-     * 팔로우 상태 토글 (팔로우 / 언팔로우)
-     * @param follower 팔로우를 요청하는 사용자 ID
-     * @param followed 팔로우 대상 사용자 ID
-     * @return 팔로우 상태 변경 성공 메시지
-     */
     @PostMapping("/{follower}/profile/{followed}")
     public ResponseEntity<String> toggleFollow(@PathVariable Long follower, @PathVariable Long followed) {
         // 팔로우 상태를 확인하고 토글 처리
         followService.toggleFollow(follower, followed);
         return ResponseEntity.ok("팔로우 상태가 변경되었습니다.");
     }
+
+    @GetMapping("/{userId}/profile/followers")
+    public ResponseEntity<List<FollowDto>> getFollowers(@PathVariable Long userId) {
+        List<FollowDto> followers = followService.getFollowerList(userId);
+        return ResponseEntity.ok(followers);
+    }
+
+
+    @GetMapping("/{userId}/profile/following")
+    public ResponseEntity<List<FollowDto>> getFollowing(@PathVariable Long userId) {
+        List<FollowDto> following = followService.getFollowingList(userId);
+        return ResponseEntity.ok(following);
+    }
+
 }

--- a/src/main/java/com/goorm/clonestagram/follow/repository/FollowRepository.java
+++ b/src/main/java/com/goorm/clonestagram/follow/repository/FollowRepository.java
@@ -15,39 +15,39 @@ import java.util.List;
 @Repository
 public interface FollowRepository extends JpaRepository<Follows, Long> {
 
-
-    // 팔로우 관계 조회 메서드 추가
+    // 팔로우 관계 조회 메서드
     Optional<Follows> findByFollowerAndFollowed(Users follower, Users followed);
 
-    // ✅ 내가 팔로우한 사람들
+    // ✅ 특정 user가 팔로우한 사람들
     @Query("SELECT f FROM Follows f WHERE f.follower = :follower AND f.follower.deleted = false AND f.followed.deleted = false")
     List<Follows> findFollowingsByFollower(@Param("follower") Users follower);
 
-    // ✅ 나를 팔로우한 사람들
+    // ✅ 특정 user를 팔로우한 사람들
     @Query("SELECT f FROM Follows f WHERE f.followed = :followed AND f.follower.deleted = false AND f.followed.deleted = false")
     List<Follows> findFollowersByFollowed(@Param("followed") Users followed);
 
-    // ✅ 나를 팔로우하는 사람들의 ID
+    // ✅ 특정 user가 팔로우하는 사람들의 ID
     @Query("SELECT f.follower.id FROM Follows f WHERE f.followed.id = :userId")
     List<Long> findFollowerIdsByFollowedId(@Param("userId") Long userId);
 
-    // ✅ 내가 팔로우하는 사람들의 ID
+    // ✅ 특정 user가 팔로우하는 사람들의 ID
     @Query("SELECT f.followed.id FROM Follows f WHERE f.follower.id = :userId")
     List<Long> findFollowingUserIdsByFollowerId(@Param("userId") Long userId);
 
     // 특정 사용자의 팔로워 수 가져오기
-    @Query("SELECT COUNT(f) FROM Follows f WHERE f.followed.id = :userId AND f.followed.deleted = false")
+    @Query("SELECT COUNT(f) FROM Follows f WHERE f.followed.id = :userId")
     int getFollowerCount(@Param("userId") Long userId);
 
     // 특정 사용자의 팔로잉 수 가져오기
-    @Query("SELECT COUNT(f) FROM Follows f WHERE f.follower.id = :userId AND f.follower.deleted = false")
+    @Query("SELECT COUNT(f) FROM Follows f WHERE f.follower.id = :userId")
     int getFollowingCount(@Param("userId") Long userId);
+
     // 내가 팔로우하는 사람 중 username에 keyword 포함된 유저
-    @Query("SELECT f.followed FROM Follows f WHERE f.follower.id = :followerId AND f.followed.username LIKE %:keyword% AND f.followed.deleted = false")
+    @Query("SELECT f.followed FROM Follows f WHERE f.follower.id = :followerId AND f.followed.username LIKE %:keyword%")
     Page<Users> findFollowingByKeyword(@Param("followerId") Long followerId, @Param("keyword") String keyword, Pageable pageable);
 
     // 나를 팔로우하는 사람 중 username에 keyword 포함된 유저
-    @Query("SELECT f.follower FROM Follows f WHERE f.followed.id = :followedId AND f.follower.username LIKE %:keyword% AND f.follower.deleted = false")
+    @Query("SELECT f.follower FROM Follows f WHERE f.followed.id = :followedId AND f.follower.username LIKE %:keyword%")
     Page<Users> findFollowerByKeyword(@Param("followedId") Long followedId, @Param("keyword") String keyword, Pageable pageable);
 
 }

--- a/src/main/java/com/goorm/clonestagram/follow/service/FollowService.java
+++ b/src/main/java/com/goorm/clonestagram/follow/service/FollowService.java
@@ -24,7 +24,6 @@ public class FollowService {
 
     @Transactional
     public void toggleFollow(Long followerId, Long followedId) {
-
         if (followerId.equals(followedId)) {
             throw new IllegalArgumentException("자기 자신을 팔로우할 수 없습니다.");
         }
@@ -33,48 +32,35 @@ public class FollowService {
         Users followed = userService.findByIdAndDeletedIsFalse(followedId);
 
         followRepository.findByFollowerAndFollowed(follower, followed)
-                .ifPresentOrElse(follows -> {
-                    followRepository.delete(follows);
-                }, () -> {
-                    Follows follows = new Follows(follower, followed);
-                    followRepository.save(follows);
-                });
+                .ifPresentOrElse(
+                        followRepository::delete,
+                        () -> followRepository.save(new Follows(follower, followed))
+                );
     }
 
 
     @Transactional(readOnly = true)
     public List<FollowDto> getFollowingList(Long userId) {
         Users user = userService.findByIdAndDeletedIsFalse(userId);
-        List<Follows> followsList = followRepository.findFollowingsByFollower(user); // ✅ 수정
-
-        if (followsList == null || followsList.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        return followsList.stream()
-                .map(FollowMapper::toFollowingDto) // ✅ 수정
+        return followRepository.findFollowingsByFollower(user).stream()
+                .map(FollowMapper::toFollowingDto)
                 .collect(Collectors.toList());
     }
+
 
     @Transactional(readOnly = true)
     public List<FollowDto> getFollowerList(Long userId) {
         Users user = userService.findByIdAndDeletedIsFalse(userId);
-        List<Follows> followsList = followRepository.findFollowersByFollowed(user);
-
-        if (followsList == null || followsList.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        return followsList.stream()
-                .map(FollowMapper::toFollowerDto) // ✅ 수정
+        return followRepository.findFollowersByFollowed(user).stream()
+                .map(FollowMapper::toFollowerDto)
                 .collect(Collectors.toList());
     }
-
 
 
     public List<Long> findFollowingUserIdsByFollowerId(Long userId){
         return followRepository.findFollowingUserIdsByFollowerId(userId);
     }
+
 
     public List<Long> findFollowerIdsByFollowedId(Long followedUserId) {
         return followRepository.findFollowerIdsByFollowedId(followedUserId);

--- a/src/test/java/com/goorm/clonestagram/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/goorm/clonestagram/follow/service/FollowServiceTest.java
@@ -1,148 +1,148 @@
-//package com.goorm.clonestagram.follow.service;
-//
-//import com.goorm.clonestagram.follow.domain.Follows;
-//import com.goorm.clonestagram.follow.dto.FollowDto;
-//import com.goorm.clonestagram.follow.repository.FollowRepository;
-//import com.goorm.clonestagram.user.domain.User;
-//import com.goorm.clonestagram.user.domain.Users;
-//import com.goorm.clonestagram.user.repository.UserRepository;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
-//import org.springframework.test.context.ActiveProfiles;
-//
-//import java.time.LocalDateTime;
-//import java.util.Collections;
-//import java.util.List;
-//import java.util.Optional;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//@ActiveProfiles("test")  // <- 이게 있어야 test 환경으로 바뀜
-//public class FollowServiceTest {
-//
-//    @Mock
-//    private FollowRepository followRepository;
-//
-//    @Mock
-//    private UserRepository userRepository;
-//
-//    @InjectMocks
-//    private FollowService followService;
-//
-//    private Users user1;
-//    private Users user2;
-//    private Follows follow;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        MockitoAnnotations.openMocks(this);
-//
-//        // Test users
-//        user1 = new Users();
-//        user1.setId(1L);
-//        user1.setUsername("user1");
-//        user1.setProfileimg("user1_profile.jpg");
-//
-//        user2 = new Users();
-//        user2.setId(2L);
-//        user2.setUsername("user2");
-//        user2.setProfileimg("user2_profile.jpg");
-//
-//        // Test follow relationship
-//        follow = new Follows(1L, user1, user2, LocalDateTime.now());
-//    }
-//
-//    @Test
-//    public void testGetFollowingList() {
-//        // Mock user repository
-//        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(user1));
-//
-//        // Mock followRepository to return a list of follows
-//        when(followRepository.findByFollowedAndDeletedIsFalse(user1)).thenReturn(Collections.singletonList(follow));
-//
-//        List<FollowDto> followingList = followService.getFollowingList(1L);
-//
-//        assertNotNull(followingList);
-//        assertEquals(1, followingList.size());
-//        assertEquals("user1", followingList.get(0).getFromUsername());
-//        assertEquals("user2", followingList.get(0).getToUsername());
-//        assertEquals("user1_profile.jpg", followingList.get(0).getFromProfileimg());
-//        assertEquals("user2_profile.jpg", followingList.get(0).getToProfileImg());
-//    }
-//
-//    @Test
-//    public void testGetFollowingListWithNoFollowings() {
-//        // Mock user repository
-//        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(user1));
-//
-//        // Mock followRepository to return empty list
-//        when(followRepository.findByFromUserAndDeletedIsFalse(user1)).thenReturn(Collections.emptyList());
-//
-//        List<FollowDto> followingList = followService.getFollowingList(1L);
-//
-//        assertNotNull(followingList);
-//        assertTrue(followingList.isEmpty());
-//    }
-//
-//    @Test
-//    public void testGetFollowerList() {
-//        // Mock user repository
-//        when(userRepository.findByIdAndDeletedIsFalse(2L)).thenReturn(Optional.of(user2));
-//
-//        // Mock followRepository to return a list of follows
-//        when(followRepository.findByToUserAndDeletedIsFalse(user2)).thenReturn(Collections.singletonList(follow));
-//
-//        List<FollowDto> followerList = followService.getFollowerList(2L);
-//
-//        assertNotNull(followerList);
-//        assertEquals(1, followerList.size());
-//        assertEquals("user1", followerList.get(0).getFromUsername());
-//        assertEquals("user2", followerList.get(0).getToUsername());
-//        assertEquals("user1_profile.jpg", followerList.get(0).getFromProfileimg());
-//        assertEquals("user2_profile.jpg", followerList.get(0).getToProfileImg());
-//    }
-//
-//    @Test
-//    public void testGetFollowerListWithNoFollowers() {
-//        // Mock user repository
-//        when(userRepository.findByIdAndDeletedIsFalse(2L)).thenReturn(Optional.of(user2));
-//
-//        // Mock followRepository to return empty list
-//        when(followRepository.findByToUserAndDeletedIsFalse(user2)).thenReturn(Collections.emptyList());
-//
-//        List<FollowDto> followerList = followService.getFollowerList(2L);
-//
-//        assertNotNull(followerList);
-//        assertTrue(followerList.isEmpty());
-//    }
-//
-//
-//    @Test
-//    public void testToggleFollow() {
-//        // Mock user repository
-//        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(user1));
-//        when(userRepository.findByIdAndDeletedIsFalse(2L)).thenReturn(Optional.of(user2));
-//
-//        // Mock followRepository to return empty result
-//        when(followRepository.findByFromUserAndToUser(user1, user2)).thenReturn(Optional.empty());
-//
-//        // Perform the toggleFollow action (follow user2 from user1)
-//        followService.toggleFollow(1L, 2L);
-//
-//        // Verify that followRepository save is called
-//        verify(followRepository, times(1)).save(any(Follows.class));
-//
-//        // Now, mock the repository to simulate the user already follows user2
-//        when(followRepository.findByFromUserAndToUser(user1, user2)).thenReturn(Optional.of(follow));
-//
-//        // Perform the toggleFollow action again (this should delete the follow)
-//        followService.toggleFollow(1L, 2L);
-//
-//        // Verify that followRepository delete is called
-//        verify(followRepository, times(1)).delete(follow);
-//    }
-//}
+package com.goorm.clonestagram.follow.service;
+
+import com.goorm.clonestagram.follow.domain.Follows;
+import com.goorm.clonestagram.follow.dto.FollowDto;
+import com.goorm.clonestagram.follow.repository.FollowRepository;
+import com.goorm.clonestagram.user.domain.Users;
+import com.goorm.clonestagram.user.domain.Users;
+import com.goorm.clonestagram.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")  // <- 이게 있어야 test 환경으로 바뀜
+public class FollowServiceTest {
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private FollowService followService;
+
+    private Users user1;
+    private Users user2;
+    private Follows follow;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        // Test users
+        user1 = new Users();
+        user1.setId(1L);
+        user1.setUsername("user1");
+        user1.setProfileimg("user1_profile.jpg");
+
+        user2 = new Users();
+        user2.setId(2L);
+        user2.setUsername("user2");
+        user2.setProfileimg("user2_profile.jpg");
+
+        // Test follow relationship
+        follow = new Follows(1L, user1, user2, LocalDateTime.now());
+    }
+
+    @Test
+    public void testGetFollowingList() {
+        // Mock user repository
+        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(user1));
+
+        // Mock followRepository to return a list of follows
+        when(followRepository.findFollowingsByFollower(user1)).thenReturn(Collections.singletonList(follow));
+
+        List<FollowDto> followingList = followService.getFollowingList(1L);
+
+        assertNotNull(followingList);
+        assertEquals(1, followingList.size());
+        assertEquals("user1", followingList.get(0).getFollowerName());
+        assertEquals("user2", followingList.get(0).getFollowedName());
+        assertEquals("user1_profile.jpg", followingList.get(0).getFollowerProfileimg());
+        assertEquals("user2_profile.jpg", followingList.get(0).getFollowedProfileImg());
+    }
+
+    @Test
+    public void testGetFollowingListWithNoFollowings() {
+        // Mock user repository
+        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(user1));
+
+        // Mock followRepository to return empty list
+        when(followRepository.findFollowersByFollowed(user1)).thenReturn(Collections.emptyList());
+
+        List<FollowDto> followingList = followService.getFollowingList(1L);
+
+        assertNotNull(followingList);
+        assertTrue(followingList.isEmpty());
+    }
+
+    @Test
+    public void testGetFollowerList() {
+        // Mock user repository
+        when(userRepository.findByIdAndDeletedIsFalse(2L)).thenReturn(Optional.of(user2));
+
+        // Mock followRepository to return a list of follows
+        when(followRepository.findFollowersByFollowed(user2)).thenReturn(Collections.singletonList(follow));
+
+        List<FollowDto> followerList = followService.getFollowerList(2L);
+
+        assertNotNull(followerList);
+        assertEquals(1, followerList.size());
+        assertEquals("user1", followerList.get(0).getFollowerName());
+        assertEquals("user2", followerList.get(0).getFollowedName());
+        assertEquals("user1_profile.jpg", followerList.get(0).getFollowerProfileimg());
+        assertEquals("user2_profile.jpg", followerList.get(0).getFollowedProfileImg());
+    }
+
+    @Test
+    public void testGetFollowerListWithNoFollowers() {
+        // Mock user repository
+        when(userRepository.findByIdAndDeletedIsFalse(2L)).thenReturn(Optional.of(user2));
+
+        // Mock followRepository to return empty list
+        when(followRepository.findFollowersByFollowed(user2)).thenReturn(Collections.emptyList());
+
+        List<FollowDto> followerList = followService.getFollowerList(2L);
+
+        assertNotNull(followerList);
+        assertTrue(followerList.isEmpty());
+    }
+
+
+    @Test
+    public void testToggleFollow() {
+        // Mock user repository
+        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(user1));
+        when(userRepository.findByIdAndDeletedIsFalse(2L)).thenReturn(Optional.of(user2));
+
+        // Mock followRepository to return empty result
+        when(followRepository.findByFollowerAndFollowed(user1, user2)).thenReturn(Optional.empty());
+
+        // Perform the toggleFollow action (follow user2 from user1)
+        followService.toggleFollow(1L, 2L);
+
+        // Verify that followRepository save is called
+        verify(followRepository, times(1)).save(any(Follows.class));
+
+        // Now, mock the repository to simulate the user already follows user2
+        when(followRepository.findByFollowerAndFollowed(user1, user2)).thenReturn(Optional.of(follow));
+
+        // Perform the toggleFollow action again (this should delete the follow)
+        followService.toggleFollow(1L, 2L);
+
+        // Verify that followRepository delete is called
+        verify(followRepository, times(1)).delete(follow);
+    }
+}

--- a/src/test/java/com/goorm/clonestagram/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/goorm/clonestagram/follow/service/FollowServiceTest.java
@@ -4,145 +4,186 @@ import com.goorm.clonestagram.follow.domain.Follows;
 import com.goorm.clonestagram.follow.dto.FollowDto;
 import com.goorm.clonestagram.follow.repository.FollowRepository;
 import com.goorm.clonestagram.user.domain.Users;
-import com.goorm.clonestagram.user.domain.Users;
-import com.goorm.clonestagram.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
+import com.goorm.clonestagram.user.service.UserService;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.test.context.ActiveProfiles;
-
-import java.time.LocalDateTime;
-import java.util.Collections;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@ActiveProfiles("test")  // <- 이게 있어야 test 환경으로 바뀜
-public class FollowServiceTest {
+
+@ExtendWith(MockitoExtension.class)
+class FollowServiceTest {
+
+    @InjectMocks
+    private FollowService followService;
 
     @Mock
     private FollowRepository followRepository;
 
     @Mock
-    private UserRepository userRepository;
-
-    @InjectMocks
-    private FollowService followService;
-
-    private Users user1;
-    private Users user2;
-    private Follows follow;
-
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-
-        // Test users
-        user1 = new Users();
-        user1.setId(1L);
-        user1.setUsername("user1");
-        user1.setProfileimg("user1_profile.jpg");
-
-        user2 = new Users();
-        user2.setId(2L);
-        user2.setUsername("user2");
-        user2.setProfileimg("user2_profile.jpg");
-
-        // Test follow relationship
-        follow = new Follows(1L, user1, user2, LocalDateTime.now());
-    }
+    private UserService userService;
 
     @Test
-    public void testGetFollowingList() {
-        // Mock user repository
-        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(user1));
+    void F01_팔로우_추가_또는_삭제_성공() {
+        // given
+        Long followerId = 1L;
+        Long followedId = 2L;
+        Users follower = Users.builder().id(followerId).build();
+        Users followed = Users.builder().id(followedId).build();
 
-        // Mock followRepository to return a list of follows
-        when(followRepository.findFollowingsByFollower(user1)).thenReturn(Collections.singletonList(follow));
+        given(userService.findByIdAndDeletedIsFalse(followerId)).willReturn(follower);
+        given(userService.findByIdAndDeletedIsFalse(followedId)).willReturn(followed);
+        given(followRepository.findByFollowerAndFollowed(follower, followed)).willReturn(Optional.empty());
 
-        List<FollowDto> followingList = followService.getFollowingList(1L);
+        // when
+        followService.toggleFollow(followerId, followedId);
 
-        assertNotNull(followingList);
-        assertEquals(1, followingList.size());
-        assertEquals("user1", followingList.get(0).getFollowerName());
-        assertEquals("user2", followingList.get(0).getFollowedName());
-        assertEquals("user1_profile.jpg", followingList.get(0).getFollowerProfileimg());
-        assertEquals("user2_profile.jpg", followingList.get(0).getFollowedProfileImg());
-    }
-
-    @Test
-    public void testGetFollowingListWithNoFollowings() {
-        // Mock user repository
-        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(user1));
-
-        // Mock followRepository to return empty list
-        when(followRepository.findFollowersByFollowed(user1)).thenReturn(Collections.emptyList());
-
-        List<FollowDto> followingList = followService.getFollowingList(1L);
-
-        assertNotNull(followingList);
-        assertTrue(followingList.isEmpty());
-    }
-
-    @Test
-    public void testGetFollowerList() {
-        // Mock user repository
-        when(userRepository.findByIdAndDeletedIsFalse(2L)).thenReturn(Optional.of(user2));
-
-        // Mock followRepository to return a list of follows
-        when(followRepository.findFollowersByFollowed(user2)).thenReturn(Collections.singletonList(follow));
-
-        List<FollowDto> followerList = followService.getFollowerList(2L);
-
-        assertNotNull(followerList);
-        assertEquals(1, followerList.size());
-        assertEquals("user1", followerList.get(0).getFollowerName());
-        assertEquals("user2", followerList.get(0).getFollowedName());
-        assertEquals("user1_profile.jpg", followerList.get(0).getFollowerProfileimg());
-        assertEquals("user2_profile.jpg", followerList.get(0).getFollowedProfileImg());
-    }
-
-    @Test
-    public void testGetFollowerListWithNoFollowers() {
-        // Mock user repository
-        when(userRepository.findByIdAndDeletedIsFalse(2L)).thenReturn(Optional.of(user2));
-
-        // Mock followRepository to return empty list
-        when(followRepository.findFollowersByFollowed(user2)).thenReturn(Collections.emptyList());
-
-        List<FollowDto> followerList = followService.getFollowerList(2L);
-
-        assertNotNull(followerList);
-        assertTrue(followerList.isEmpty());
+        // then
+        verify(followRepository).save(any(Follows.class));
     }
 
 
     @Test
-    public void testToggleFollow() {
-        // Mock user repository
-        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(user1));
-        when(userRepository.findByIdAndDeletedIsFalse(2L)).thenReturn(Optional.of(user2));
+    void F02_자기자신_팔로우시_예외발생() {
+        Long sameId = 1L;
 
-        // Mock followRepository to return empty result
-        when(followRepository.findByFollowerAndFollowed(user1, user2)).thenReturn(Optional.empty());
+        assertThrows(IllegalArgumentException.class, () -> followService.toggleFollow(sameId, sameId));
+    }
 
-        // Perform the toggleFollow action (follow user2 from user1)
-        followService.toggleFollow(1L, 2L);
 
-        // Verify that followRepository save is called
-        verify(followRepository, times(1)).save(any(Follows.class));
+    @Test
+    void F03_팔로잉_목록_조회_성공() {
+        Long userId = 1L;
+        Users user = Users.builder().id(userId).build();
+        Users other = Users.builder().id(2L).username("상대유저").build();
 
-        // Now, mock the repository to simulate the user already follows user2
-        when(followRepository.findByFollowerAndFollowed(user1, user2)).thenReturn(Optional.of(follow));
+        Follows follow = new Follows(user, other);
 
-        // Perform the toggleFollow action again (this should delete the follow)
-        followService.toggleFollow(1L, 2L);
+        given(userService.findByIdAndDeletedIsFalse(userId)).willReturn(user);
+        given(followRepository.findFollowingsByFollower(user)).willReturn(List.of(follow));
 
-        // Verify that followRepository delete is called
-        verify(followRepository, times(1)).delete(follow);
+        List<FollowDto> result = followService.getFollowingList(userId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getFollowedId()).isEqualTo(2L);
+    }
+
+
+    @Test
+    void F04_팔로워_목록_조회_성공() {
+        Long userId = 1L;
+        Users user = Users.builder().id(userId).build();
+        Users follower = Users.builder().id(2L).username("팔로워").build();
+
+        Follows follow = new Follows(follower, user);
+
+        given(userService.findByIdAndDeletedIsFalse(userId)).willReturn(user);
+        given(followRepository.findFollowersByFollowed(user)).willReturn(List.of(follow));
+
+        List<FollowDto> result = followService.getFollowerList(userId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getFollowerId()).isEqualTo(2L);
+    }
+
+
+    @Test
+    void F05_팔로잉_ID_목록_조회_성공() {
+        Long userId = 1L;
+        List<Long> followingIds = List.of(2L, 3L);
+
+        given(followRepository.findFollowingUserIdsByFollowerId(userId)).willReturn(followingIds);
+
+        List<Long> result = followService.findFollowingUserIdsByFollowerId(userId);
+
+        assertThat(result).isEqualTo(followingIds);
+    }
+
+
+    @Test
+    void F06_팔로워_ID_목록_조회_성공() {
+        Long userId = 1L;
+        List<Long> followerIds = List.of(4L, 5L);
+
+        given(followRepository.findFollowerIdsByFollowedId(userId)).willReturn(followerIds);
+
+        List<Long> result = followService.findFollowerIdsByFollowedId(userId);
+
+        assertThat(result).isEqualTo(followerIds);
+    }
+
+
+    @Test
+    void F07_팔로잉_목록_조회_유저없음_예외발생() {
+        // given
+        Long userId = 99L;
+        given(userService.findByIdAndDeletedIsFalse(userId))
+                .willThrow(new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> followService.getFollowingList(userId));
+    }
+
+
+    @Test
+    void F08_팔로워_목록_조회_유저없음_예외발생() {
+        // given
+        Long userId = 99L;
+        given(userService.findByIdAndDeletedIsFalse(userId))
+                .willThrow(new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> followService.getFollowerList(userId));
+    }
+
+
+    @Test
+    void F09_팔로잉_ID_목록_조회_빈리스트_반환() {
+        Long userId = 1L;
+        given(followRepository.findFollowingUserIdsByFollowerId(userId)).willReturn(List.of());
+
+        List<Long> result = followService.findFollowingUserIdsByFollowerId(userId);
+
+        assertThat(result).isEmpty();
+    }
+
+
+    @Test
+    void F10_팔로잉_목록_조회_빈리스트_반환() {
+        // given
+        Long userId = 1L;
+        Users user = Users.builder().id(userId).build();
+
+        given(userService.findByIdAndDeletedIsFalse(userId)).willReturn(user);
+        given(followRepository.findFollowingsByFollower(user)).willReturn(List.of());
+
+        // when
+        List<FollowDto> result = followService.getFollowingList(userId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+
+    @Test
+    void F11_팔로워_목록_조회_빈리스트_반환() {
+        // given
+        Long userId = 1L;
+        Users user = Users.builder().id(userId).build();
+
+        given(userService.findByIdAndDeletedIsFalse(userId)).willReturn(user);
+        given(followRepository.findFollowersByFollowed(user)).willReturn(List.of());
+
+        // when
+        List<FollowDto> result = followService.getFollowerList(userId);
+
+        // then
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/com/goorm/clonestagram/like/service/LikeServiceIntegrationTest.java
+++ b/src/test/java/com/goorm/clonestagram/like/service/LikeServiceIntegrationTest.java
@@ -1,105 +1,105 @@
-//package com.goorm.clonestagram.like.service;
-//
-//import com.goorm.clonestagram.post.domain.Posts;
-//import com.goorm.clonestagram.post.repository.PostsRepository;
-//import com.goorm.clonestagram.like.domain.Like;
-//import com.goorm.clonestagram.like.repository.LikeRepository;
-//import com.goorm.clonestagram.user.domain.User;
-//import com.goorm.clonestagram.user.repository.UserRepository;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.test.context.ActiveProfiles;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import java.util.Optional;
-//
-//import static com.goorm.clonestagram.post.ContentType.IMAGE;
-//import static com.goorm.clonestagram.post.ContentType.VIDEO;
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//@ActiveProfiles("test")  // <- 이게 있어야 test 환경으로 바뀜
-//@SpringBootTest
-//@Transactional
-//public class LikeServiceIntegrationTest {
-//
-//    @Autowired
-//    private LikeService likeService;
-//
-//    @Autowired
-//    private UserRepository userRepository;
-//
-//    @Autowired
-//    private PostsRepository postsRepository;
-//
-//    @Autowired
-//    private LikeRepository likeRepository;
-//
-//    @Test
-//    public void testToggleLike() {
-//        // Given: 테스트용 사용자와 게시물 생성
-//        User user = new User();
-//        user.setUsername("testUser");
-//        user.setEmail("test@example.com");
-//        user.setPassword("password");
-//        user.setDeleted(false);
-//        user = userRepository.save(user);
-//
-//        Posts post = new Posts();
-//        post.setUser(user);
-//        post.setContent("Test Post");
-//        post.setContentType(IMAGE);  // contents_type 추가
-//        post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
-//        post.setDeleted(false);
-//        post = postsRepository.save(post);
-//
-//        // When: 좋아요 토글 (첫 번째 좋아요)
-//        likeService.toggleLike(user.getId(), post.getId());
-//
-//        // Then: 좋아요가 제대로 생성되었는지 확인
-//        Optional<Like> like = likeRepository.findByUserIdAndPostsId(user.getId(), post.getId());
-//        assertTrue(like.isPresent(), "좋아요가 생성되어야 합니다.");
-//        assertEquals(1L, likeService.getLikeCount(post.getId()), "좋아요 개수가 1이어야 합니다.");
-//
-//        // When: 좋아요 다시 토글 (좋아요 취소)
-//        likeService.toggleLike(user.getId(), post.getId());
-//
-//        // Then: 좋아요가 제대로 취소되었는지 확인
-//        like = likeRepository.findByUserIdAndPostsId(user.getId(), post.getId());
-//        assertFalse(like.isPresent(), "좋아요가 취소되어야 합니다.");
-//        assertEquals(0L, likeService.getLikeCount(post.getId()), "좋아요 개수가 0이어야 합니다.");
-//    }
-//
-//    @Test
-//    public void testGetLikeCount() {
-//        // Given: 테스트용 사용자와 게시물, 다중 좋아요 생성
-//        User user1 = new User();
-//        user1.setUsername("user1");
-//        user1.setEmail("user1@example.com");
-//        user1.setPassword("password1");
-//        user1.setDeleted(false);
-//        user1 = userRepository.save(user1);
-//
-//        User user2 = new User();
-//        user2.setUsername("user2");
-//        user2.setEmail("user2@example.com");
-//        user2.setPassword("password2");
-//        user2.setDeleted(false);
-//        user2 = userRepository.save(user2);
-//
-//        Posts post = new Posts();
-//        post.setUser(user1);
-//        post.setContent("Test Post1");
-//        post.setContentType(IMAGE);  // contents_type 추가
-//        post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
-//        post.setDeleted(false);
-//        post = postsRepository.save(post);
-//
-//        // When: 두 사용자가 좋아요
-//        likeService.toggleLike(user1.getId(), post.getId());
-//        likeService.toggleLike(user2.getId(), post.getId());
-//
-//        // Then: 좋아요 개수 확인
-//        assertEquals(2L, likeService.getLikeCount(post.getId()), "좋아요 개수가 2이어야 합니다.");
-//    }
-//}
+package com.goorm.clonestagram.like.service;
+
+import com.goorm.clonestagram.post.domain.Posts;
+import com.goorm.clonestagram.post.repository.PostsRepository;
+import com.goorm.clonestagram.like.domain.Like;
+import com.goorm.clonestagram.like.repository.LikeRepository;
+import com.goorm.clonestagram.user.domain.Users;
+import com.goorm.clonestagram.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.goorm.clonestagram.post.ContentType.IMAGE;
+import static com.goorm.clonestagram.post.ContentType.VIDEO;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")  // <- 이게 있어야 test 환경으로 바뀜
+@SpringBootTest
+@Transactional
+public class LikeServiceIntegrationTest {
+
+    @Autowired
+    private LikeService likeService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostsRepository postsRepository;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Test
+    public void testToggleLike() {
+        // Given: 테스트용 사용자와 게시물 생성
+        Users user = new Users();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setDeleted(false);
+        user = userRepository.save(user);
+
+        Posts post = new Posts();
+        post.setUser(user);
+        post.setContent("Test Post");
+        post.setContentType(IMAGE);  // contents_type 추가
+        post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
+        post.setDeleted(false);
+        post = postsRepository.save(post);
+
+        // When: 좋아요 토글 (첫 번째 좋아요)
+        likeService.toggleLike(user.getId(), post.getId());
+
+        // Then: 좋아요가 제대로 생성되었는지 확인
+        Optional<Like> like = likeRepository.findByUser_IdAndPost_Id(user.getId(), post.getId());
+        assertTrue(like.isPresent(), "좋아요가 생성되어야 합니다.");
+        assertEquals(1L, likeService.getLikeCount(post.getId()), "좋아요 개수가 1이어야 합니다.");
+
+        // When: 좋아요 다시 토글 (좋아요 취소)
+        likeService.toggleLike(user.getId(), post.getId());
+
+        // Then: 좋아요가 제대로 취소되었는지 확인
+        like = likeRepository.findByUser_IdAndPost_Id(user.getId(), post.getId());
+        assertFalse(like.isPresent(), "좋아요가 취소되어야 합니다.");
+        assertEquals(0L, likeService.getLikeCount(post.getId()), "좋아요 개수가 0이어야 합니다.");
+    }
+
+    @Test
+    public void testGetLikeCount() {
+        // Given: 테스트용 사용자와 게시물, 다중 좋아요 생성
+        Users user1 = new Users();
+        user1.setUsername("user1");
+        user1.setEmail("user1@example.com");
+        user1.setPassword("password1");
+        user1.setDeleted(false);
+        user1 = userRepository.save(user1);
+
+        Users user2 = new Users();
+        user2.setUsername("user2");
+        user2.setEmail("user2@example.com");
+        user2.setPassword("password2");
+        user2.setDeleted(false);
+        user2 = userRepository.save(user2);
+
+        Posts post = new Posts();
+        post.setUser(user1);
+        post.setContent("Test Post1");
+        post.setContentType(IMAGE);  // contents_type 추가
+        post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
+        post.setDeleted(false);
+        post = postsRepository.save(post);
+
+        // When: 두 사용자가 좋아요
+        likeService.toggleLike(user1.getId(), post.getId());
+        likeService.toggleLike(user2.getId(), post.getId());
+
+        // Then: 좋아요 개수 확인
+        assertEquals(2L, likeService.getLikeCount(post.getId()), "좋아요 개수가 2이어야 합니다.");
+    }
+}

--- a/src/test/java/com/goorm/clonestagram/post/service/ImageServiceTest.java
+++ b/src/test/java/com/goorm/clonestagram/post/service/ImageServiceTest.java
@@ -1,283 +1,283 @@
-//package com.goorm.clonestagram.post.service;
-//
-//import com.goorm.clonestagram.feed.service.FeedService;
-//import com.goorm.clonestagram.hashtag.repository.PostHashTagRepository;
-//import com.goorm.clonestagram.post.ContentType;
-//import com.goorm.clonestagram.post.EntityType;
-//import com.goorm.clonestagram.post.domain.Posts;
-//import com.goorm.clonestagram.post.domain.SoftDelete;
-//import com.goorm.clonestagram.post.dto.update.ImageUpdateReqDto;
-//import com.goorm.clonestagram.post.dto.update.ImageUpdateResDto;
-//import com.goorm.clonestagram.post.dto.upload.ImageUploadReqDto;
-//import com.goorm.clonestagram.post.dto.upload.ImageUploadResDto;
-//import com.goorm.clonestagram.post.repository.PostsRepository;
-//import com.goorm.clonestagram.post.repository.SoftDeleteRepository;
-//import com.goorm.clonestagram.user.domain.User;
-//import com.goorm.clonestagram.user.repository.UserRepository;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
-//import org.springframework.mock.web.MockMultipartFile;
-//import org.springframework.test.context.ActiveProfiles;
-//import org.springframework.test.util.ReflectionTestUtils;
-//
-//import java.io.IOException;
-//import java.nio.file.Files;
-//import java.nio.file.Path;
-//import java.nio.file.Paths;
-//import java.util.Optional;
-//import java.util.UUID;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.*;
-//
-////Todo 로그인 구현 완료 후 유저를 포함하여 테스트 필요
-//@ActiveProfiles("test")  // <- 이게 있어야 test 환경으로 바뀜
-//class ImageServiceTest {
-//
-//
-//    private ImageUploadReqDto imageUploadReqDto;
-//    private ImageUpdateReqDto imageUpdateReqDto;
-//
-//    @Mock
-//    private PostsRepository postsRepository;
-//
-//    @Mock
-//    private UserRepository userRepository;
-//
-//    @Mock
-//    private FeedService feedService; // ✅ FeedService Mock 추가
-//
-//    @Mock
-//    private SoftDeleteRepository softDeleteRepository;
-//
-//    @Mock
-//    private PostHashTagRepository postHashTagRepository;
-//
-//    @InjectMocks
-//    private ImageService imageService;
-//
-//    @BeforeEach
-//    void setUp(){
-//        MockitoAnnotations.openMocks(this);
-//        imageUploadReqDto = new ImageUploadReqDto();
-//        imageUpdateReqDto = new ImageUpdateReqDto();
-//    }
-//
-//    /**
-//     * imageUpload()가 동작하는지 테스트
-//     */
-//    @Test
-//    public void 파일업로드() throws Exception{
-//        // given: Mock 파일과 유저 설정 및 Stubbing
-//        /**
-//         * - 가상 파일 생성
-//         * - Dto에 관련 데이터 셋팅
-//         * - 가상 User 생성
-//         * - findById : 가상 유저 ID로 실행시 가상 유저 객체 반환
-//         * - save : Posts 객체 저장 시 Posts 객체 반환
-//         */
-//        String mockMultipartFile = ".jpg";
-//
-//        imageUploadReqDto.setFile(mockMultipartFile);
-//        imageUploadReqDto.setContent("테스트 내용");
-//
-//        User testUser = User.builder()
-//                .id(1L)
-//                .username("testuser")
-//                .email("testuser@example.com")
-//                .password("1234")
-//                .build();
-//
-//        Posts savedPost = Posts.builder()
-//                .id(100L)
-//                .content("테스트 내용")
-//                .contentType(ContentType.IMAGE)
-//                .user(testUser)
-//                .build();
-//
-//        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(testUser));
-//        when(postsRepository.save(any(Posts.class))).thenAnswer(invocation -> invocation.getArgument(0));
-//
-//        // when: 이미지 업로드 서비스 실행
-//        ImageUploadResDto imageUploadResDto = imageService.imageUpload(imageUploadReqDto, testUser.getId());
-//
-//        // then: 응답 및 호출 검증
-//        /**
-//         * - Dto가 null이 아닌지 확인
-//         * - userRepository.findById()가 실행되었는지 확인
-//         * - postsRepository.save()가 실행되었는지 확인
-//         */
-//        assertNotNull(imageUploadResDto);
-//        verify(userRepository).findByIdAndDeletedIsFalse(testUser.getId());
-//        verify(postsRepository).save(any(Posts.class));
-//        verify(feedService).createFeedForFollowers(any(Posts.class)); // ✅ feedService 호출 확인
-//    }
-//
-//    /**
-//     * imageUpdate()가 동작하는지 테스트
-//     */
-//    @Test
-//    public void 파일업데이트(){
-//        //given : 가상 데이터 생성, stubbing
-//        /**
-//         * - 가상 파일 생성(old, new)
-//         * - 가상 유저 생성
-//         * - 가상 게시글 생성
-//         * - findById : ID가 1L와 같으면 가상 게시글 반환
-//         * - save : Posts객체를 저장하면 Posts객체 반환
-//         */
-//        MockMultipartFile oldFile = new MockMultipartFile(
-//                "file", "old-image.jpg","image/jpeg","dummy image content".getBytes()
-//        );
-//
-//        User testUser = User.builder()
-//                .id(1L)
-//                .username("testuser")
-//                .email("testuser@example.com")
-//                .password("1234")
-//                .build();
-//
-//        Posts tempPost = Posts.builder()
-//                .id(1L)
-//                .content("수정전 내용")
-//                .mediaName(oldFile.getOriginalFilename())
-//                .contentType(ContentType.IMAGE)
-//                .user(testUser)
-//                .build();
-//
-//        String newFile = "new-image.jpg";
-//        ImageUpdateReqDto reqDto = new ImageUpdateReqDto();
-//        reqDto.setFile(newFile);
-//        reqDto.setContent("수정된 내용");
-//
-//        when(postsRepository.findByIdAndDeletedIsFalse(eq(1L))).thenReturn(Optional.of(tempPost));
-//        when(postsRepository.save(any(Posts.class))).thenAnswer(invocation -> invocation.getArgument(0));
-//
-//        //when : imageUpdate() 실행
-//        ImageUpdateResDto imageUpdateResDto = imageService.imageUpdate(tempPost.getId(), reqDto, testUser.getId());
-//
-//        //then : 응답 데이터 검증
-//        /**
-//         * - Dto가 null이 아닌지 확인
-//         * - content가 수정되었는지 확인
-//         * - findById가 실행되었는지 확인
-//         * - save가 실행되었는지 확인
-//         */
-//        assertNotNull(imageUpdateResDto);
-//        assertEquals("수정된 내용", imageUpdateResDto.getContent());
-//        verify(postsRepository).findByIdAndDeletedIsFalse(tempPost.getId());
-//        verify(postsRepository).save(any(Posts.class));
-//    }
-//
-//    /**
-//     * imageDelete()가 동작하는지 테스트
-//     */
-//    @Test
-//    public void 파일삭제(){
-//        //given : 가상 데이터 생성, stubbing
-//        /**
-//         * - 가상 파일 생성
-//         * - 가상 유저 생성
-//         * - 가상 게시글 생성
-//         * - findById : ID가 1L와 같으면 가상 게시글 반환
-//         */
-//        MockMultipartFile mockMultipartFile = new MockMultipartFile(
-//                "file", "image.jpg","image/jpeg","dummy image content".getBytes()
-//        );
-//
-//        User testUser = User.builder()
-//                .id(1L)
-//                .username("testuser")
-//                .email("testuser@example.com")
-//                .password("1234")
-//                .build();
-//
-//        Posts tempPost = Posts.builder()
-//                .id(1L)
-//                .content("수정전 내용")
-//                .mediaName(mockMultipartFile.getOriginalFilename())
-//                .contentType(ContentType.IMAGE)
-//                .user(testUser)
-//                .build();
-//
-//        when(postsRepository.findByIdAndDeletedIsFalse(eq(1L))).thenReturn(Optional.of(tempPost));
-//        when(softDeleteRepository.save(any(SoftDelete.class))).thenAnswer(invocation -> invocation.getArgument(0));
-//        doNothing().when(postHashTagRepository).deleteAllByPostsId(eq(1L));
-//
-//        //when : imageDelete 실행
-//        imageService.imageDelete(tempPost.getId(), testUser.getId());
-//
-//        //then : 응답 데이터 검증
-//        /**
-//         * - findById가 실행되었는지 확인
-//         * - delete가 실행되었는지 확인
-//         */
-//        verify(postsRepository).findByIdAndDeletedIsFalse(tempPost.getId());
-//        verify(postHashTagRepository).deleteAllByPostsId(tempPost.getId());
-//        verify(softDeleteRepository).save(any(SoftDelete.class));
-//        verify(feedService).deleteFeedByPostId(tempPost.getId()); // ✅ feedService 호출 확인
-//    }
-//
-//    /**
-//     * 유저가 존재하지 않을시 발생하는 에러 테스트
-//     */
-//    @Test
-//    public void 해당_유저를_찾을_수_없습니다(){
-//        //given : 가상 데이터 생성, stubbing
-//        /**
-//         * 가상 파일 생성
-//         * 가상 데이터 셋팅
-//         * findById : 유저의 Id가 1L과 같으면 빈 객체 반환
-//         */
-//        String mockMultipartFile = "image.jpg";
-//
-//        imageUploadReqDto.setFile(mockMultipartFile);
-//        imageUploadReqDto.setContent("파일생성");
-//
-//        when(userRepository.findByIdAndDeletedIsFalse(eq(1L))).thenReturn(Optional.empty());
-//
-//        //when : imageUpload() 실행
-//        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-//                () -> imageService.imageUpload(imageUploadReqDto, 1L));
-//
-//        //then : 응답 데이터 검증
-//        /**
-//         * - "해당 유저를 찾을 수 없습니다." 에러 메세지 반환 확인
-//         * - findById 동작 확인
-//         */
-//        assertEquals("해당 유저를 찾을 수 없습니다.", exception.getMessage());
-//        verify(userRepository).findByIdAndDeletedIsFalse(1L);
-//    }
-//
-//    /**
-//     * 게시글이 존재하지 않을시 발생하는 에러 테스트
-//     */
-//    @Test
-//    public void 게시물을_찾을_수_없습니다(){
-//        //given : stubbing
-//        when(postsRepository.findByIdAndDeletedIsFalse(eq(1L))).thenReturn(Optional.empty());
-//
-//        //when : imageUpdate(),imageDelete() 실행
-//        IllegalArgumentException updateException = assertThrows(IllegalArgumentException.class,
-//                () -> imageService.imageUpdate(1L,imageUpdateReqDto, 1L));
-//
-//        IllegalArgumentException deleteException = assertThrows(IllegalArgumentException.class,
-//                () -> imageService.imageDelete(1L,1L));
-//
-//        //then : 응답 데이터 검증
-//        /**
-//         * - "게시물을 찾을 수 없습니다" 에러 메세지 반환 확인
-//         * - "해당 게시물이 없습니다" 에러 메세지 반환 확인
-//         * - findById가 2번 실행되었는지 확인
-//         */
-//        assertEquals("게시물을 찾을 수 없습니다", updateException.getMessage());
-//        assertEquals("해당 게시물이 없습니다", deleteException.getMessage());
-//        verify(postsRepository,times(2)).findByIdAndDeletedIsFalse(1L);
-//    }
-//}
-//
+package com.goorm.clonestagram.post.service;
+
+import com.goorm.clonestagram.feed.service.FeedService;
+import com.goorm.clonestagram.hashtag.repository.PostHashTagRepository;
+import com.goorm.clonestagram.post.ContentType;
+import com.goorm.clonestagram.post.EntityType;
+import com.goorm.clonestagram.post.domain.Posts;
+import com.goorm.clonestagram.post.domain.SoftDelete;
+import com.goorm.clonestagram.post.dto.update.ImageUpdateReqDto;
+import com.goorm.clonestagram.post.dto.update.ImageUpdateResDto;
+import com.goorm.clonestagram.post.dto.upload.ImageUploadReqDto;
+import com.goorm.clonestagram.post.dto.upload.ImageUploadResDto;
+import com.goorm.clonestagram.post.repository.PostsRepository;
+import com.goorm.clonestagram.post.repository.SoftDeleteRepository;
+import com.goorm.clonestagram.user.domain.Users;
+import com.goorm.clonestagram.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+//Todo 로그인 구현 완료 후 유저를 포함하여 테스트 필요
+@ActiveProfiles("test")  // <- 이게 있어야 test 환경으로 바뀜
+class ImageServiceTest {
+
+
+    private ImageUploadReqDto imageUploadReqDto;
+    private ImageUpdateReqDto imageUpdateReqDto;
+
+    @Mock
+    private PostsRepository postsRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FeedService feedService; // ✅ FeedService Mock 추가
+
+    @Mock
+    private SoftDeleteRepository softDeleteRepository;
+
+    @Mock
+    private PostHashTagRepository postHashTagRepository;
+
+    @InjectMocks
+    private ImageService imageService;
+
+    @BeforeEach
+    void setUp(){
+        MockitoAnnotations.openMocks(this);
+        imageUploadReqDto = new ImageUploadReqDto();
+        imageUpdateReqDto = new ImageUpdateReqDto();
+    }
+
+    /**
+     * imageUpload()가 동작하는지 테스트
+     */
+    @Test
+    public void 파일업로드() throws Exception{
+        // given: Mock 파일과 유저 설정 및 Stubbing
+        /**
+         * - 가상 파일 생성
+         * - Dto에 관련 데이터 셋팅
+         * - 가상 User 생성
+         * - findById : 가상 유저 ID로 실행시 가상 유저 객체 반환
+         * - save : Posts 객체 저장 시 Posts 객체 반환
+         */
+        String mockMultipartFile = ".jpg";
+
+        imageUploadReqDto.setFile(mockMultipartFile);
+        imageUploadReqDto.setContent("테스트 내용");
+
+        Users testUser = Users.builder()
+                .id(1L)
+                .username("testuser")
+                .email("testuser@example.com")
+                .password("1234")
+                .build();
+
+        Posts savedPost = Posts.builder()
+                .id(100L)
+                .content("테스트 내용")
+                .contentType(ContentType.IMAGE)
+                .user(testUser)
+                .build();
+
+        when(userRepository.findByIdAndDeletedIsFalse(1L)).thenReturn(Optional.of(testUser));
+        when(postsRepository.save(any(Posts.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when: 이미지 업로드 서비스 실행
+        ImageUploadResDto imageUploadResDto = imageService.imageUpload(imageUploadReqDto, testUser.getId());
+
+        // then: 응답 및 호출 검증
+        /**
+         * - Dto가 null이 아닌지 확인
+         * - userRepository.findById()가 실행되었는지 확인
+         * - postsRepository.save()가 실행되었는지 확인
+         */
+        assertNotNull(imageUploadResDto);
+        verify(userRepository).findByIdAndDeletedIsFalse(testUser.getId());
+        verify(postsRepository).save(any(Posts.class));
+        verify(feedService).createFeedForFollowers(any(Posts.class)); // ✅ feedService 호출 확인
+    }
+
+    /**
+     * imageUpdate()가 동작하는지 테스트
+     */
+    @Test
+    public void 파일업데이트(){
+        //given : 가상 데이터 생성, stubbing
+        /**
+         * - 가상 파일 생성(old, new)
+         * - 가상 유저 생성
+         * - 가상 게시글 생성
+         * - findById : ID가 1L와 같으면 가상 게시글 반환
+         * - save : Posts객체를 저장하면 Posts객체 반환
+         */
+        MockMultipartFile oldFile = new MockMultipartFile(
+                "file", "old-image.jpg","image/jpeg","dummy image content".getBytes()
+        );
+
+        Users testUser = Users.builder()
+                .id(1L)
+                .username("testuser")
+                .email("testuser@example.com")
+                .password("1234")
+                .build();
+
+        Posts tempPost = Posts.builder()
+                .id(1L)
+                .content("수정전 내용")
+                .mediaName(oldFile.getOriginalFilename())
+                .contentType(ContentType.IMAGE)
+                .user(testUser)
+                .build();
+
+        String newFile = "new-image.jpg";
+        ImageUpdateReqDto reqDto = new ImageUpdateReqDto();
+        reqDto.setFile(newFile);
+        reqDto.setContent("수정된 내용");
+
+        when(postsRepository.findByIdAndDeletedIsFalse(eq(1L))).thenReturn(Optional.of(tempPost));
+        when(postsRepository.save(any(Posts.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        //when : imageUpdate() 실행
+        ImageUpdateResDto imageUpdateResDto = imageService.imageUpdate(tempPost.getId(), reqDto, testUser.getId());
+
+        //then : 응답 데이터 검증
+        /**
+         * - Dto가 null이 아닌지 확인
+         * - content가 수정되었는지 확인
+         * - findById가 실행되었는지 확인
+         * - save가 실행되었는지 확인
+         */
+        assertNotNull(imageUpdateResDto);
+        assertEquals("수정된 내용", imageUpdateResDto.getContent());
+        verify(postsRepository).findByIdAndDeletedIsFalse(tempPost.getId());
+        verify(postsRepository).save(any(Posts.class));
+    }
+
+    /**
+     * imageDelete()가 동작하는지 테스트
+     */
+    @Test
+    public void 파일삭제(){
+        //given : 가상 데이터 생성, stubbing
+        /**
+         * - 가상 파일 생성
+         * - 가상 유저 생성
+         * - 가상 게시글 생성
+         * - findById : ID가 1L와 같으면 가상 게시글 반환
+         */
+        MockMultipartFile mockMultipartFile = new MockMultipartFile(
+                "file", "image.jpg","image/jpeg","dummy image content".getBytes()
+        );
+
+        Users testUser = Users.builder()
+                .id(1L)
+                .username("testuser")
+                .email("testuser@example.com")
+                .password("1234")
+                .build();
+
+        Posts tempPost = Posts.builder()
+                .id(1L)
+                .content("수정전 내용")
+                .mediaName(mockMultipartFile.getOriginalFilename())
+                .contentType(ContentType.IMAGE)
+                .user(testUser)
+                .build();
+
+        when(postsRepository.findByIdAndDeletedIsFalse(eq(1L))).thenReturn(Optional.of(tempPost));
+        when(softDeleteRepository.save(any(SoftDelete.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doNothing().when(postHashTagRepository).deleteAllByPostsId(eq(1L));
+
+        //when : imageDelete 실행
+        imageService.imageDelete(tempPost.getId(), testUser.getId());
+
+        //then : 응답 데이터 검증
+        /**
+         * - findById가 실행되었는지 확인
+         * - delete가 실행되었는지 확인
+         */
+        verify(postsRepository).findByIdAndDeletedIsFalse(tempPost.getId());
+        verify(postHashTagRepository).deleteAllByPostsId(tempPost.getId());
+        verify(softDeleteRepository).save(any(SoftDelete.class));
+        verify(feedService).deleteFeedsByPostId(tempPost.getId()); // ✅ feedService 호출 확인
+    }
+
+    /**
+     * 유저가 존재하지 않을시 발생하는 에러 테스트
+     */
+    @Test
+    public void 해당_유저를_찾을_수_없습니다(){
+        //given : 가상 데이터 생성, stubbing
+        /**
+         * 가상 파일 생성
+         * 가상 데이터 셋팅
+         * findById : 유저의 Id가 1L과 같으면 빈 객체 반환
+         */
+        String mockMultipartFile = "image.jpg";
+
+        imageUploadReqDto.setFile(mockMultipartFile);
+        imageUploadReqDto.setContent("파일생성");
+
+        when(userRepository.findByIdAndDeletedIsFalse(eq(1L))).thenReturn(Optional.empty());
+
+        //when : imageUpload() 실행
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> imageService.imageUpload(imageUploadReqDto, 1L));
+
+        //then : 응답 데이터 검증
+        /**
+         * - "해당 유저를 찾을 수 없습니다." 에러 메세지 반환 확인
+         * - findById 동작 확인
+         */
+        assertEquals("해당 유저를 찾을 수 없습니다.", exception.getMessage());
+        verify(userRepository).findByIdAndDeletedIsFalse(1L);
+    }
+
+    /**
+     * 게시글이 존재하지 않을시 발생하는 에러 테스트
+     */
+    @Test
+    public void 게시물을_찾을_수_없습니다(){
+        //given : stubbing
+        when(postsRepository.findByIdAndDeletedIsFalse(eq(1L))).thenReturn(Optional.empty());
+
+        //when : imageUpdate(),imageDelete() 실행
+        IllegalArgumentException updateException = assertThrows(IllegalArgumentException.class,
+                () -> imageService.imageUpdate(1L,imageUpdateReqDto, 1L));
+
+        IllegalArgumentException deleteException = assertThrows(IllegalArgumentException.class,
+                () -> imageService.imageDelete(1L,1L));
+
+        //then : 응답 데이터 검증
+        /**
+         * - "게시물을 찾을 수 없습니다" 에러 메세지 반환 확인
+         * - "해당 게시물이 없습니다" 에러 메세지 반환 확인
+         * - findById가 2번 실행되었는지 확인
+         */
+        assertEquals("게시물을 찾을 수 없습니다", updateException.getMessage());
+        assertEquals("해당 게시물이 없습니다", deleteException.getMessage());
+        verify(postsRepository,times(2)).findByIdAndDeletedIsFalse(1L);
+    }
+}
+

--- a/src/test/java/com/goorm/clonestagram/post/service/ProfileServiceTest.java
+++ b/src/test/java/com/goorm/clonestagram/post/service/ProfileServiceTest.java
@@ -1,96 +1,96 @@
-//package com.goorm.clonestagram.post.service;
-//
-//import com.goorm.clonestagram.user.domain.Users;
-//import com.goorm.clonestagram.user.repository.UserRepository;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.test.context.ActiveProfiles;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertNotNull;
-//
-//@SpringBootTest
-//@ActiveProfiles("test")  // <- 이게 있어야 test 환경으로 바뀜
-//public class ProfileServiceTest {
-//
-//    @Autowired
-//    private UserRepository userRepository;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        userRepository.deleteAll(); // 테스트 실행 전 기존 데이터 삭제
-//    }
-//
-//    @Test
-//    public void updateUserProfile_Success() {
-//        // Given
-//        Users users = Users.builder()
-//                .username("testuser")  // 필수 필드 추가
-//                .password("password123")  // 필수 필드 추가
-//                .email("testuser@example.com")  // 필수 필드 추가
-//                .profileimg("http://example.com/profile.jpg")
-//                .bio("안녕하세요. 테스트 사용자입니다.")
-//                .build();
-//
-//        // When
-//        Users savedUsers = userRepository.save(users);
-//
-//        // Then
-//        assertNotNull(savedUsers.getId());
-//        assertEquals("testuser", savedUsers.getUsername());
-//        assertEquals("testuser@example.com", savedUsers.getEmail());
-//        assertEquals("http://example.com/profile.jpg", savedUsers.getProfileimg());
-//        assertEquals("안녕하세요. 테스트 사용자입니다.", savedUsers.getBio());
-//    }
-//
-//    @Test
-//    public void getUserProfile_Success() {
-//        // Given
-//        Users users = Users.builder()
-//                .username("testuser2")
-//                .password("password456")
-//                .email("testuser2@example.com")
-//                .profileimg("http://example.com/profile2.jpg")
-//                .bio("두 번째 사용자입니다.")
-//                .build();
-//        userRepository.save(users);
-//
-//        // When
-//        Users foundUsers = userRepository.findByIdAndDeletedIsFalse(users.getId()).orElse(null);
-//
-//        // Then
-//        assertNotNull(foundUsers);
-//        assertEquals("testuser2", foundUsers.getUsername());
-//        assertEquals("testuser2@example.com", foundUsers.getEmail());
-//        assertEquals("http://example.com/profile2.jpg", foundUsers.getProfileimg());
-//        assertEquals("두 번째 사용자입니다.", foundUsers.getBio());
-//    }
-//
-//    @Test
-//    public void updateProfileImage_Success() {
-//        // Given
-//        Users users = Users.builder()
-//                .username("testuser3")
-//                .password("password789")
-//                .email("testuser3@example.com")
-//                .profileimg("http://example.com/profile3.jpg")
-//                .bio("세 번째 사용자입니다.")
-//                .build();
-//        Users savedUsers = userRepository.save(users);
-//
-//        // When
-//        savedUsers.setUsername("testuser4");
-//        savedUsers.setEmail("testuser4@example.com");
-//        savedUsers.setBio("update!");
-//        savedUsers.setProfileimg("http://example.com/newprofile3.jpg");
-//        Users updatedUsers = userRepository.save(savedUsers);
-//
-//        // Then
-//        assertEquals("http://example.com/newprofile3.jpg", updatedUsers.getProfileimg());
-//        assertEquals("update!", updatedUsers.getBio());
-//        assertEquals("testuser4", updatedUsers.getUsername());
-//        assertEquals("testuser4@example.com", updatedUsers.getEmail());
-//    }
-//}
+package com.goorm.clonestagram.post.service;
+
+import com.goorm.clonestagram.user.domain.Users;
+import com.goorm.clonestagram.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@ActiveProfiles("test")  // <- 이게 있어야 test 환경으로 바뀜
+public class ProfileServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    public void setUp() {
+        userRepository.deleteAll(); // 테스트 실행 전 기존 데이터 삭제
+    }
+
+    @Test
+    public void updateUserProfile_Success() {
+        // Given
+        Users users = Users.builder()
+                .username("testuser")  // 필수 필드 추가
+                .password("password123")  // 필수 필드 추가
+                .email("testuser@example.com")  // 필수 필드 추가
+                .profileimg("http://example.com/profile.jpg")
+                .bio("안녕하세요. 테스트 사용자입니다.")
+                .build();
+
+        // When
+        Users savedUsers = userRepository.save(users);
+
+        // Then
+        assertNotNull(savedUsers.getId());
+        assertEquals("testuser", savedUsers.getUsername());
+        assertEquals("testuser@example.com", savedUsers.getEmail());
+        assertEquals("http://example.com/profile.jpg", savedUsers.getProfileimg());
+        assertEquals("안녕하세요. 테스트 사용자입니다.", savedUsers.getBio());
+    }
+
+    @Test
+    public void getUserProfile_Success() {
+        // Given
+        Users users = Users.builder()
+                .username("testuser2")
+                .password("password456")
+                .email("testuser2@example.com")
+                .profileimg("http://example.com/profile2.jpg")
+                .bio("두 번째 사용자입니다.")
+                .build();
+        userRepository.save(users);
+
+        // When
+        Users foundUsers = userRepository.findByIdAndDeletedIsFalse(users.getId()).orElse(null);
+
+        // Then
+        assertNotNull(foundUsers);
+        assertEquals("testuser2", foundUsers.getUsername());
+        assertEquals("testuser2@example.com", foundUsers.getEmail());
+        assertEquals("http://example.com/profile2.jpg", foundUsers.getProfileimg());
+        assertEquals("두 번째 사용자입니다.", foundUsers.getBio());
+    }
+
+    @Test
+    public void updateProfileImage_Success() {
+        // Given
+        Users users = Users.builder()
+                .username("testuser3")
+                .password("password789")
+                .email("testuser3@example.com")
+                .profileimg("http://example.com/profile3.jpg")
+                .bio("세 번째 사용자입니다.")
+                .build();
+        Users savedUsers = userRepository.save(users);
+
+        // When
+        savedUsers.setUsername("testuser4");
+        savedUsers.setEmail("testuser4@example.com");
+        savedUsers.setBio("update!");
+        savedUsers.setProfileimg("http://example.com/newprofile3.jpg");
+        Users updatedUsers = userRepository.save(savedUsers);
+
+        // Then
+        assertEquals("http://example.com/newprofile3.jpg", updatedUsers.getProfileimg());
+        assertEquals("update!", updatedUsers.getBio());
+        assertEquals("testuser4", updatedUsers.getUsername());
+        assertEquals("testuser4@example.com", updatedUsers.getEmail());
+    }
+}

--- a/src/test/java/com/goorm/clonestagram/user/service/ProfileServiceIntegrationTest.java
+++ b/src/test/java/com/goorm/clonestagram/user/service/ProfileServiceIntegrationTest.java
@@ -1,96 +1,94 @@
-//package com.goorm.clonestagram.user.service;
-//
-//import com.goorm.clonestagram.user.domain.User;
-//import com.goorm.clonestagram.user.dto.UserProfileDto;
-//import com.goorm.clonestagram.user.dto.UserProfileUpdateDto;
-//import com.goorm.clonestagram.user.repository.UserRepository;
-//import com.goorm.clonestagram.follow.repository.FollowRepository;
-//import com.goorm.clonestagram.post.repository.PostsRepository;
-//import com.goorm.clonestagram.post.service.ImageService;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.test.context.ActiveProfiles;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//@SpringBootTest
-//@Transactional
-//@ActiveProfiles("test") // application-test.properties를 사용하기 위해 설정
-//public class ProfileServiceIntegrationTest {
-//
-//    @Autowired
-//    private ProfileService profileService;
-//
-//    @Autowired
-//    private UserRepository userRepository;
-//
-//    @Autowired
-//    private FollowRepository followRepository;
-//
-//    @Autowired
-//    private PostsRepository postsRepository;
-//
-//    @Autowired
-//    private ImageService imageService;
-//
-//    private User testUser;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        // 테스트용 유저 생성
-//        testUser = User.builder()
-//                .username("testUser")
-//                .email("test@example.com")
-//                .password("testPassword")
-//                .profileimg("default-profile-img.jpg")
-//                .bio("This is a test bio")
-//                .build();
-//        userRepository.save(testUser);
-//    }
-//
-//    @Test
-//    public void testGetUserProfile() {
-//        // 테스트: 사용자 프로필 조회
-//        UserProfileDto userProfile = profileService.getUserProfile(testUser.getId());
-//
-//        assertNotNull(userProfile);
-//        assertEquals(testUser.getId(), userProfile.getId());
-//        assertEquals(testUser.getUsername(), userProfile.getUsername());
-//        assertEquals(testUser.getProfileimg(), userProfile.getProfileimg());
-//    }
-//
-//    @Test
-//    public void testUpdateUserProfile() {
-//        // 테스트: 사용자 프로필 수정
-//        UserProfileUpdateDto updateDto = new UserProfileUpdateDto();
-//        updateDto.setUsername("updatedUser");
-//        updateDto.setBio("Updated bio");
-//
-//        // 이미지 업로드는 Mock 처리해야 할 수 있음, 테스트 목적상 필드값만 업데이트
-//        UserProfileDto updatedUser = profileService.updateUserProfile(testUser.getId(), updateDto);
-//
-//        assertNotNull(updatedUser);
-//        assertEquals("updatedUser", updatedUser.getUsername());
-//        assertEquals("Updated bio", updatedUser.getBio());
-//    }
-//
-//    @Test
-//    public void testUpdateUserProfileWithImage() {
-//        // 이미지 업로드가 포함된 프로필 업데이트 테스트
-//        UserProfileUpdateDto updateDto = new UserProfileUpdateDto();
-//        updateDto.setUsername("userWithNewProfileImage");
-//        updateDto.setBio("Updated bio with image");
-//
-//        // 실제 이미지 업로드는 Mock 처리할 수 있지만, 여기에선 이미지만 업데이트하는 테스트
-//        UserProfileDto updatedUser = profileService.updateUserProfile(testUser.getId(), updateDto);
-//
-//        assertNotNull(updatedUser);
-//        assertEquals("userWithNewProfileImage", updatedUser.getUsername());
-//        assertEquals("Updated bio with image", updatedUser.getBio());
-//        // 실제 이미지 URL 확인 (업로드된 파일이 저장된 경로 등)
-//        assertTrue(updatedUser.getProfileimg().contains("default-profile-img.jpg"));
-//    }
-//}
+package com.goorm.clonestagram.user.service;
+
+import com.goorm.clonestagram.user.domain.Users;
+import com.goorm.clonestagram.user.dto.UserProfileDto;
+import com.goorm.clonestagram.user.dto.UserProfileUpdateDto;
+import com.goorm.clonestagram.user.repository.UserRepository;
+import com.goorm.clonestagram.follow.repository.FollowRepository;
+import com.goorm.clonestagram.post.repository.PostsRepository;
+import com.goorm.clonestagram.post.service.ImageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test") // application-test.properties를 사용하기 위해 설정
+public class ProfileServiceIntegrationTest {
+
+    @Autowired
+    private ProfileService profileService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    @Autowired
+    private PostsRepository postsRepository;
+
+    @Autowired
+    private ImageService imageService;
+
+    private Users testUser;
+
+    @BeforeEach
+    public void setUp() {
+        // 테스트용 유저 생성
+        testUser = Users.builder()
+                .username("testUser")
+                .email("test@example.com")
+                .password("testPassword")
+                .profileimg("default-profile-img.jpg")
+                .bio("This is a test bio")
+                .build();
+        userRepository.save(testUser);
+    }
+
+    @Test
+    public void testGetUserProfile() {
+        // 테스트: 사용자 프로필 조회
+        UserProfileDto userProfile = profileService.getUserProfile(testUser.getId());
+
+        assertNotNull(userProfile);
+        assertEquals(testUser.getId(), userProfile.getId());
+        assertEquals(testUser.getUsername(), userProfile.getUsername());
+        assertEquals(testUser.getProfileimg(), userProfile.getProfileimg());
+    }
+
+    @Test
+    public void testUpdateUserProfile() {
+        // 테스트: 사용자 프로필 수정
+        UserProfileUpdateDto updateDto = new UserProfileUpdateDto();
+        updateDto.setBio("Updated bio");
+
+        // 이미지 업로드는 Mock 처리해야 할 수 있음, 테스트 목적상 필드값만 업데이트
+        UserProfileDto updatedUser = profileService.updateUserProfile(testUser.getId(), updateDto);
+
+        assertNotNull(updatedUser);
+        assertEquals("updatedUser", updatedUser.getUsername());
+        assertEquals("Updated bio", updatedUser.getBio());
+    }
+
+    @Test
+    public void testUpdateUserProfileWithImage() {
+        // 이미지 업로드가 포함된 프로필 업데이트 테스트
+        UserProfileUpdateDto updateDto = new UserProfileUpdateDto();
+        updateDto.setBio("Updated bio with image");
+
+        // 실제 이미지 업로드는 Mock 처리할 수 있지만, 여기에선 이미지만 업데이트하는 테스트
+        UserProfileDto updatedUser = profileService.updateUserProfile(testUser.getId(), updateDto);
+
+        assertNotNull(updatedUser);
+        assertEquals("userWithNewProfileImage", updatedUser.getUsername());
+        assertEquals("Updated bio with image", updatedUser.getBio());
+        // 실제 이미지 URL 확인 (업로드된 파일이 저장된 경로 등)
+        assertTrue(updatedUser.getProfileimg().contains("default-profile-img.jpg"));
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the follow functionality in the `clonestagram` project. The changes involve modifications to the `FollowController`, `FollowRepository`, and `FollowService` classes, as well as updates to the corresponding tests in `FollowServiceTest`.

### Controller Changes:
* [`FollowController.java`](diffhunk://#diff-cfdc365b94cf91ec284284e21007a41a70404dc1b4c644e3f953b3e2db61f89dL17-L50): Added a new `toggleFollow` method to handle follow/unfollow actions and removed redundant comments.

### Repository Changes:
* [`FollowRepository.java`](diffhunk://#diff-ca630c11ead1fed69fa21e0329b4bcc11c0558254cf455776fa6d35d8de0c339L18-R50): Simplified and clarified comments for query methods and removed unnecessary conditions in queries.

### Service Changes:
* [`FollowService.java`](diffhunk://#diff-99d297b874fb678543baa2b442639bf10d109e90f15f9757640283e629409b53L27): Refactored the `toggleFollow` method to use method references and streamlined the `getFollowingList` and `getFollowerList` methods by removing null checks and directly returning the stream results. [[1]](diffhunk://#diff-99d297b874fb678543baa2b442639bf10d109e90f15f9757640283e629409b53L27) [[2]](diffhunk://#diff-99d297b874fb678543baa2b442639bf10d109e90f15f9757640283e629409b53L36-R64)

### Test Changes:
* [`FollowServiceTest.java`](diffhunk://#diff-86b3c234df2d9295a31bd00f2b87bdeaadfe95169971273046240dc74effb185L1-R189): Rewritten the test class with modern Mockito and JUnit 5 practices, including new test cases for various scenarios.