### PR TITLE
test: 댓글 컨트롤러 단위 테스트

### DIFF
--- a/src/main/java/com/goorm/clonestagram/comment/controller/CommentController.java
+++ b/src/main/java/com/goorm/clonestagram/comment/controller/CommentController.java
@@ -26,9 +26,9 @@ public class CommentController {
 	public CommentResponse getCommentById(@PathVariable Long id) {
 		Comments entity = commentService.getCommentById(id);
 
-		if (entity == null) {
-			return CommentResponse.builder().build();
-		}
+		// if (entity == null) {
+		// 	return CommentResponse.builder().build();
+		// }
 		return CommentResponse.builder()
 			.id(entity.getId())
 			.userId(entity.getUsers().getId())

--- a/src/main/java/com/goorm/clonestagram/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goorm/clonestagram/common/exception/GlobalExceptionHandler.java
@@ -1,12 +1,17 @@
 package com.goorm.clonestagram.common.exception;
 
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.http.HttpStatus;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import com.goorm.clonestagram.exception.CommentNotFoundException;
 
 /**
  * Global Exception Handler
@@ -17,43 +22,53 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    /**
-     * IllegalArgumentException 처리 메서드
-     * - 잘못된 파라미터, 요청 값 등에 의해서 IllegalArgumentException 발생 시
-     * - 에러 메시지를 클라이언트에게 JSON 응답으로 반환
-     *
-     * @param e 발생한 IllegalArgumentException
-     * @return 400 Bad Request 상태코드 + 에러 메시지
-     */
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponseDto> handleBadRequest(IllegalArgumentException e){
-        ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
-                .errorMessage(e.getMessage()) // 발생한 예외의 메시지를 담음
-                .build();
-        return ResponseEntity.badRequest().body(errorResponseDto); // HTTP 400 상태로 응답
-    }
+	/**
+	 * IllegalArgumentException 처리 메서드
+	 * - 잘못된 파라미터, 요청 값 등에 의해서 IllegalArgumentException 발생 시
+	 * - 에러 메시지를 클라이언트에게 JSON 응답으로 반환
+	 *
+	 * @param e 발생한 IllegalArgumentException
+	 * @return 400 Bad Request 상태코드 + 에러 메시지
+	 */
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponseDto> handleBadRequest(IllegalArgumentException e) {
+		ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
+			.errorMessage(e.getMessage()) // 발생한 예외의 메시지를 담음
+			.build();
+		return ResponseEntity.badRequest().body(errorResponseDto); // HTTP 400 상태로 응답
+	}
 
-    /**
-     * RuntimeException 처리 메서드
-     * - 런타임 오류 처리
-     * - 클라이언트에게 JSON 형식으로 에러 메시지 반환
-     *
-     * @param e 발생한 RuntimeException
-     * @return 400 Bad Request 상태코드 + 에러 메시지 (필요에 따라 500 응답으로 변경 가능)
-     */
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ErrorResponseDto> handleServerError(RuntimeException e){
-        ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
-                .errorMessage(e.getMessage())
-                .build();
-        return ResponseEntity.badRequest().body(errorResponseDto);
-    }
+	/**
+	 * RuntimeException 처리 메서드
+	 * - 런타임 오류 처리
+	 * - 클라이언트에게 JSON 형식으로 에러 메시지 반환
+	 *
+	 * @param e 발생한 RuntimeException
+	 * @return 400 Bad Request 상태코드 + 에러 메시지 (필요에 따라 500 응답으로 변경 가능)
+	 */
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ErrorResponseDto> handleServerError(RuntimeException e) {
+		ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
+			.errorMessage(e.getMessage())
+			.build();
+		return ResponseEntity.badRequest().body(errorResponseDto);
+	}
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponseDto> handleValidationExceptions(MethodArgumentNotValidException e) {
-        ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
-                .errorMessage(e.getMessage())
-                .build();
-        return ResponseEntity.badRequest().body(errorResponseDto);
-    }
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponseDto> handleValidationExceptions(MethodArgumentNotValidException e) {
+		ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
+			.errorMessage(e.getMessage())
+			.build();
+		return ResponseEntity.badRequest().body(errorResponseDto);
+	}
+
+	@ExceptionHandler(CommentNotFoundException.class)
+	public ResponseEntity<ProblemDetail> handleCommentNotFound(CommentNotFoundException ex) {
+		ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+		problem.setTitle("댓글을 찾을 수 없습니다");
+		problem.setDetail(ex.getMessage());
+
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problem);
+	}
+
 }

--- a/src/main/java/com/goorm/clonestagram/exception/InvalidCommentException.java
+++ b/src/main/java/com/goorm/clonestagram/exception/InvalidCommentException.java
@@ -1,0 +1,8 @@
+package com.goorm.clonestagram.exception;
+
+public class InvalidCommentException extends RuntimeException {
+
+	public InvalidCommentException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/goorm/clonestagram/exception/PermissionDeniedException.java
+++ b/src/main/java/com/goorm/clonestagram/exception/PermissionDeniedException.java
@@ -1,0 +1,12 @@
+package com.goorm.clonestagram.exception;
+
+public class PermissionDeniedException extends RuntimeException {
+
+	public PermissionDeniedException() {
+		super("해당 작업을 수행할 권한이 없습니다.");
+	}
+
+	public PermissionDeniedException(String message) {
+		super(message);
+	}
+}

--- a/src/test/java/com/goorm/clonestagram/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/goorm/clonestagram/comment/controller/CommentControllerTest.java
@@ -1,0 +1,269 @@
+package com.goorm.clonestagram.comment.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goorm.clonestagram.comment.domain.Comments;
+import com.goorm.clonestagram.comment.dto.CommentRequest;
+import com.goorm.clonestagram.comment.dto.CommentResponse;
+import com.goorm.clonestagram.comment.service.CommentService;
+import com.goorm.clonestagram.exception.CommentNotFoundException;
+import com.goorm.clonestagram.exception.InvalidCommentException;
+import com.goorm.clonestagram.exception.PermissionDeniedException;
+import com.goorm.clonestagram.exception.PostNotFoundException;
+import com.goorm.clonestagram.exception.UserNotFoundException;
+import com.goorm.clonestagram.post.domain.Posts;
+import com.goorm.clonestagram.user.domain.Users;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentControllerTest {
+	@Mock
+	private CommentService commentService;
+
+	@InjectMocks
+	CommentController commentController;
+
+	// 댓글 ID로 조회: 성공, 실패 - 없는ID
+	@Nested
+	@DisplayName("댓글 ID로 조회 테스트")
+	class GetCommentByIdTest {
+
+		@Test
+		@DisplayName("댓글 조회에 성공하면 정상적으로 객체가 반환된다.")
+		void success() {
+			// given
+			Users user = new Users();
+			user.setId(100L);
+
+			Posts post = new Posts();
+			post.setId(200L);
+
+			Comments comment = new Comments();
+			comment.setId(1L);
+			comment.setUsers(user);
+			comment.setPosts(post);
+			comment.setContent("댓글 내용");
+			comment.setCreatedAt(LocalDateTime.now());
+
+			when(commentService.getCommentById(1L)).thenReturn(comment);
+
+			// when
+			CommentResponse response = commentController.getCommentById(1L);
+
+			// then
+			assertEquals(1L, response.getId());
+			assertEquals("댓글 내용", response.getContent());
+		}
+
+		@Test
+		@DisplayName("없는 ID로 조회하면 404 발생")
+		void fail_notFound() {
+			// given
+			Long id = 999L;
+			when(commentService.getCommentById(id)).thenThrow(new CommentNotFoundException(id));
+
+			// when + then
+			assertThrows(CommentNotFoundException.class, () -> {
+				commentController.getCommentById(id);
+			});
+		}
+
+	}
+
+	@Nested
+	@DisplayName("포스트 ID로 조회 테스트")
+	class GetCommentByPostIdTest {
+		@Test
+		@DisplayName("댓글 조회에 성공하면 해당 포스트에 달린 댓글의 리스트가 반환된다.")
+		void success() {
+			// given
+			Long postId = 10L;
+
+			Users user = new Users();
+			user.setId(100L);
+
+			Posts post = new Posts();
+			post.setId(postId);
+
+			Comments comment = new Comments();
+			comment.setId(1L);
+			comment.setUsers(user);
+			comment.setPosts(post);
+			comment.setContent("내용");
+			comment.setCreatedAt(LocalDateTime.now());
+
+			when(commentService.getCommentsByPostId(postId)).thenReturn(List.of(comment));
+
+			// when
+			List<CommentResponse> responses = commentController.getCommentsByPostId(postId);
+
+			// then
+			assertEquals(1, responses.size());
+			assertEquals("내용", responses.get(0).getContent());
+			assertEquals(100L, responses.get(0).getUserId());
+		}
+
+		@Test
+		@DisplayName("해당 포스트에 댓글이 없는 경우 빈 리스트가 반환된다.")
+		void success_empty_list() {
+			// given
+			when(commentService.getCommentsByPostId(anyLong())).thenReturn(Collections.emptyList());
+
+			// when
+			List<CommentResponse> result = commentController.getCommentsByPostId(100L);
+
+			// then
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("없는 포스트 ID로 조회하면 404 발생")
+		void fail_not_found() {
+			// given
+			Long postId = 999L;
+			when(commentService.getCommentsByPostId(postId)).thenThrow(new PostNotFoundException(postId));
+
+			// when + then
+			assertThrows(PostNotFoundException.class, () -> {
+				commentController.getCommentsByPostId(postId);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("댓글 저장 테스트")
+	class CreateTest {
+		@Test
+		@DisplayName("댓글 저장에 성공하면 정상적으로 객체가 반환된다.")
+		void success() throws Exception {
+			// given
+			CommentRequest request = new CommentRequest(1L, 2L, "댓글");
+
+			Users user = new Users();
+			user.setId(1L);
+
+			Posts post = new Posts();
+			post.setId(2L);
+
+			Comments saved = new Comments();
+			saved.setId(10L);
+			saved.setUsers(user);
+			saved.setPosts(post);
+			saved.setContent("댓글");
+			saved.setCreatedAt(LocalDateTime.now());
+
+			when(commentService.createComment(request)).thenReturn(saved);
+
+			// when
+			CommentResponse response = commentController.create(request);
+
+			// then
+			assertEquals(10L, response.getId());
+			assertEquals("댓글", response.getContent());
+			assertEquals(1L, response.getUserId());
+			assertEquals(2L, response.getPostId());
+		}
+
+		@Test
+		@DisplayName("없는 사용자인 경우 예외 발생")
+		void fail_user_not_found() throws Exception {
+			CommentRequest request = new CommentRequest(999L, 2L, "내용");
+			when(commentService.createComment(request)).thenThrow(new UserNotFoundException(999L));
+
+			assertThrows(UserNotFoundException.class, () -> {
+				commentController.create(request);
+			});
+		}
+
+		@Test
+		@DisplayName("없는 포스트인 경우 예외 발생")
+		void fail_post_not_found() {
+			CommentRequest request = new CommentRequest(1L, 999L, "내용");
+			when(commentService.createComment(request)).thenThrow(new PostNotFoundException(999L));
+
+			assertThrows(PostNotFoundException.class, () -> {
+				commentController.create(request);
+			});
+		}
+
+		@Test
+		@DisplayName("내용이 없는 댓글인 경우 예외 발생")
+		void fail_no_contents() {
+			CommentRequest request = new CommentRequest(1L, 2L, ""); // or null
+
+			when(commentService.createComment(request)).thenThrow(new InvalidCommentException("내용이 없습니다"));
+
+			assertThrows(InvalidCommentException.class, () -> {
+				commentController.create(request);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("댓글 삭제 테스트")
+	class DeleteCommentTest {
+		@Test
+		@DisplayName("댓글 작성자가 댓글 삭제를 시도하는 경우 정상적으로 실행된다.")
+		void success_comment_writer() {
+			Long commentId = 1L;
+			Long userId = 100L;
+
+			doNothing().when(commentService).removeComment(commentId, userId);
+
+			String result = commentController.deleteComment(commentId, userId);
+
+			assertEquals("댓글이 삭제되었습니다. ID: " + commentId, result);
+		}
+
+		@Test
+		@DisplayName("포스트 작성자가 댓글 삭제를 시도하는 경우 정상적으로 실행된다.")
+		void success_post_writer() {
+			Long commentId = 1L;
+			Long postOwnerId = 200L;
+
+			doNothing().when(commentService).removeComment(commentId, postOwnerId);
+
+			String result = commentController.deleteComment(commentId, postOwnerId);
+
+			assertEquals("댓글이 삭제되었습니다. ID: " + commentId, result);
+		}
+
+		@Test
+		@DisplayName("권한이 없는 사용자가 삭제를 시도하는 경우 예외발생, 403발생")
+		void fail_no_permission() {
+			Long commentId = 1L;
+			Long invalidUserId = 999L;
+
+			doThrow(new PermissionDeniedException()).when(commentService).removeComment(commentId, invalidUserId);
+
+			assertThrows(PermissionDeniedException.class, () -> {
+				commentController.deleteComment(commentId, invalidUserId);
+			});
+		}
+
+		@Test
+		@DisplayName("없는 댓글을 삭제하려 하는 경우 예외 발생")
+		void fail_not_found() {
+			Long commentId = 999L;
+			Long requesterId = 1L;
+
+			doThrow(new CommentNotFoundException(commentId)).when(commentService).removeComment(commentId, requesterId);
+
+			assertThrows(CommentNotFoundException.class, () -> {
+				commentController.deleteComment(commentId, requesterId);
+			});
+		}
+	}
+}

--- a/src/test/java/com/goorm/clonestagram/comment/controller/CommentControllerTest.java~
+++ b/src/test/java/com/goorm/clonestagram/comment/controller/CommentControllerTest.java~
@@ -1,0 +1,273 @@
+package com.goorm.clonestagram.comment.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goorm.clonestagram.comment.domain.Comments;
+import com.goorm.clonestagram.comment.dto.CommentRequest;
+import com.goorm.clonestagram.comment.dto.CommentResponse;
+import com.goorm.clonestagram.comment.service.CommentService;
+import com.goorm.clonestagram.exception.CommentNotFoundException;
+import com.goorm.clonestagram.exception.InvalidCommentException;
+import com.goorm.clonestagram.exception.PermissionDeniedException;
+import com.goorm.clonestagram.exception.PostNotFoundException;
+import com.goorm.clonestagram.exception.UserNotFoundException;
+import com.goorm.clonestagram.post.domain.Posts;
+import com.goorm.clonestagram.user.domain.Users;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentControllerTest {
+	@Mock
+	private CommentService commentService;
+
+	@InjectMocks
+	CommentController commentController;
+
+	public static final String BASE = "/comments";
+	public static final String BY_ID = BASE + "/{commentId}";
+	public static final String BY_POST = BASE + "/post/{postId}";
+
+	// 댓글 ID로 조회: 성공, 실패 - 없는ID
+	@Nested
+	@DisplayName("댓글 ID로 조회 테스트")
+	class GetCommentByIdTest {
+
+		@Test
+		@DisplayName("댓글 조회에 성공하면 정상적으로 객체가 반환된다.")
+		void success() {
+			// given
+			Users user = new Users();
+			user.setId(100L);
+
+			Posts post = new Posts();
+			post.setId(200L);
+
+			Comments comment = new Comments();
+			comment.setId(1L);
+			comment.setUsers(user);
+			comment.setPosts(post);
+			comment.setContent("댓글 내용");
+			comment.setCreatedAt(LocalDateTime.now());
+
+			when(commentService.getCommentById(1L)).thenReturn(comment);
+
+			// when
+			CommentResponse response = commentController.getCommentById(1L);
+
+			// then
+			assertEquals(1L, response.getId());
+			assertEquals("댓글 내용", response.getContent());
+		}
+
+		@Test
+		@DisplayName("없는 ID로 조회하면 404 발생")
+		void fail_notFound() {
+			// given
+			Long id = 999L;
+			when(commentService.getCommentById(id)).thenThrow(new CommentNotFoundException(id));
+
+			// when + then
+			assertThrows(CommentNotFoundException.class, () -> {
+				commentController.getCommentById(id);
+			});
+		}
+
+	}
+
+	@Nested
+	@DisplayName("포스트 ID로 조회 테스트")
+	class GetCommentByPostIdTest {
+		@Test
+		@DisplayName("댓글 조회에 성공하면 해당 포스트에 달린 댓글의 리스트가 반환된다.")
+		void success() {
+			// given
+			Long postId = 10L;
+
+			Users user = new Users();
+			user.setId(100L);
+
+			Posts post = new Posts();
+			post.setId(postId);
+
+			Comments comment = new Comments();
+			comment.setId(1L);
+			comment.setUsers(user);
+			comment.setPosts(post);
+			comment.setContent("내용");
+			comment.setCreatedAt(LocalDateTime.now());
+
+			when(commentService.getCommentsByPostId(postId)).thenReturn(List.of(comment));
+
+			// when
+			List<CommentResponse> responses = commentController.getCommentsByPostId(postId);
+
+			// then
+			assertEquals(1, responses.size());
+			assertEquals("내용", responses.get(0).getContent());
+			assertEquals(100L, responses.get(0).getUserId());
+		}
+
+		@Test
+		@DisplayName("해당 포스트에 댓글이 없는 경우 빈 리스트가 반환된다.")
+		void success_empty_list() {
+			// given
+			when(commentService.getCommentsByPostId(anyLong())).thenReturn(Collections.emptyList());
+
+			// when
+			List<CommentResponse> result = commentController.getCommentsByPostId(100L);
+
+			// then
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("없는 포스트 ID로 조회하면 404 발생")
+		void fail_not_found() {
+			// given
+			Long postId = 999L;
+			when(commentService.getCommentsByPostId(postId)).thenThrow(new PostNotFoundException(postId));
+
+			// when + then
+			assertThrows(PostNotFoundException.class, () -> {
+				commentController.getCommentsByPostId(postId);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("댓글 저장 테스트")
+	class CreateTest {
+		@Test
+		@DisplayName("댓글 저장에 성공하면 정상적으로 객체가 반환된다.")
+		void success() throws Exception {
+			// given
+			CommentRequest request = new CommentRequest(1L, 2L, "댓글");
+
+			Users user = new Users();
+			user.setId(1L);
+
+			Posts post = new Posts();
+			post.setId(2L);
+
+			Comments saved = new Comments();
+			saved.setId(10L);
+			saved.setUsers(user);
+			saved.setPosts(post);
+			saved.setContent("댓글");
+			saved.setCreatedAt(LocalDateTime.now());
+
+			when(commentService.createComment(request)).thenReturn(saved);
+
+			// when
+			CommentResponse response = commentController.create(request);
+
+			// then
+			assertEquals(10L, response.getId());
+			assertEquals("댓글", response.getContent());
+			assertEquals(1L, response.getUserId());
+			assertEquals(2L, response.getPostId());
+		}
+
+		@Test
+		@DisplayName("없는 사용자인 경우 예외 발생")
+		void fail_user_not_found() throws Exception {
+			CommentRequest request = new CommentRequest(999L, 2L, "내용");
+			when(commentService.createComment(request)).thenThrow(new UserNotFoundException(999L));
+
+			assertThrows(UserNotFoundException.class, () -> {
+				commentController.create(request);
+			});
+		}
+
+		@Test
+		@DisplayName("없는 포스트인 경우 예외 발생")
+		void fail_post_not_found() {
+			CommentRequest request = new CommentRequest(1L, 999L, "내용");
+			when(commentService.createComment(request)).thenThrow(new PostNotFoundException(999L));
+
+			assertThrows(PostNotFoundException.class, () -> {
+				commentController.create(request);
+			});
+		}
+
+		@Test
+		@DisplayName("내용이 없는 댓글인 경우 예외 발생")
+		void fail_no_contents() {
+			CommentRequest request = new CommentRequest(1L, 2L, ""); // or null
+
+			when(commentService.createComment(request)).thenThrow(new InvalidCommentException("내용이 없습니다"));
+
+			assertThrows(InvalidCommentException.class, () -> {
+				commentController.create(request);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("댓글 삭제 테스트")
+	class DeleteCommentTest {
+		@Test
+		@DisplayName("댓글 작성자가 댓글 삭제를 시도하는 경우 정상적으로 실행된다.")
+		void success_comment_writer() {
+			Long commentId = 1L;
+			Long userId = 100L;
+
+			doNothing().when(commentService).removeComment(commentId, userId);
+
+			String result = commentController.deleteComment(commentId, userId);
+
+			assertEquals("댓글이 삭제되었습니다. ID: " + commentId, result);
+		}
+
+		@Test
+		@DisplayName("포스트 작성자가 댓글 삭제를 시도하는 경우 정상적으로 실행된다.")
+		void success_post_writer() {
+			Long commentId = 1L;
+			Long postOwnerId = 200L;
+
+			doNothing().when(commentService).removeComment(commentId, postOwnerId);
+
+			String result = commentController.deleteComment(commentId, postOwnerId);
+
+			assertEquals("댓글이 삭제되었습니다. ID: " + commentId, result);
+		}
+
+		@Test
+		@DisplayName("권한이 없는 사용자가 삭제를 시도하는 경우 예외발생, 403발생")
+		void fail_no_permission() {
+			Long commentId = 1L;
+			Long invalidUserId = 999L;
+
+			doThrow(new PermissionDeniedException()).when(commentService).removeComment(commentId, invalidUserId);
+
+			assertThrows(PermissionDeniedException.class, () -> {
+				commentController.deleteComment(commentId, invalidUserId);
+			});
+		}
+
+		@Test
+		@DisplayName("없는 댓글을 삭제하려 하는 경우 예외 발생")
+		void fail_not_found() {
+			Long commentId = 999L;
+			Long requesterId = 1L;
+
+			doThrow(new CommentNotFoundException(commentId)).when(commentService).removeComment(commentId, requesterId);
+
+			assertThrows(CommentNotFoundException.class, () -> {
+				commentController.deleteComment(commentId, requesterId);
+			});
+		}
+	}
+}


### PR DESCRIPTION
댓글 ID로 조회: 성공, 실패 - 없는ID
포스트ID로 조회: 성공, 실패 - 없는ID
댓글 저장: 성공, 실패 - 작성자 없음/포스트 없음/내용 없음
댓글 삭제: 성공 - 댓글 작성자/포스트 작성자, 실패 - 권한 없음/없는 댓글

Fixes: #28