### PR TITLE
좋아요 카운트 테이블 구현

### DIFF
--- a/src/main/java/com/goorm/clonestagram/follow/controller/FollowController.java
+++ b/src/main/java/com/goorm/clonestagram/follow/controller/FollowController.java
@@ -2,42 +2,39 @@ package com.goorm.clonestagram.follow.controller;
 
 import com.goorm.clonestagram.follow.dto.FollowDto;
 import com.goorm.clonestagram.follow.service.FollowService;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/follow")
 public class FollowController {
 
-	private final FollowService followService;
+    private final FollowService followService;
 
-	@PostMapping(
-		value = "/{follower}/profile/{followed}"
-		//produces = MediaType.TEXT_PLAIN_VALUE + ";charset=UTF-8"
-	)
-	public ResponseEntity<String> toggleFollow(@PathVariable Long follower, @PathVariable Long followed) {
-		// 팔로우 상태를 확인하고 토글 처리
-		followService.toggleFollow(follower, followed);
-		return ResponseEntity.ok("팔로우 상태가 변경되었습니다.");
-	}
+    @PostMapping(
+            value = "/{follower}/profile/{followed}"
+    )
+    public ResponseEntity<String> toggleFollow(@PathVariable Long follower, @PathVariable Long followed) {
+        // 팔로우 상태를 확인하고 토글 처리
+        followService.toggleFollow(follower, followed);
+        return ResponseEntity.ok("팔로우 상태가 변경되었습니다.");
+    }
 
-	@GetMapping("/{userId}/profile/followers")
-	public ResponseEntity<List<FollowDto>> getFollowers(@PathVariable Long userId) {
-		List<FollowDto> followers = followService.getFollowerList(userId);
-		return ResponseEntity.ok(followers);
-	}
+    @GetMapping("/{userId}/profile/followers")
+    public ResponseEntity<List<FollowDto>> getFollowers(@PathVariable Long userId) {
+        List<FollowDto> followers = followService.getFollowerList(userId);
+        return ResponseEntity.ok(followers);
+    }
 
-	@GetMapping("/{userId}/profile/following")
-	public ResponseEntity<List<FollowDto>> getFollowing(@PathVariable Long userId) {
-		List<FollowDto> following = followService.getFollowingList(userId);
-		return ResponseEntity.ok(following);
-	}
+
+    @GetMapping("/{userId}/profile/following")
+    public ResponseEntity<List<FollowDto>> getFollowing(@PathVariable Long userId) {
+        List<FollowDto> following = followService.getFollowingList(userId);
+        return ResponseEntity.ok(following);
+    }
 
 }

--- a/src/main/java/com/goorm/clonestagram/follow/controller/FollowController.java~
+++ b/src/main/java/com/goorm/clonestagram/follow/controller/FollowController.java~
@@ -19,7 +19,7 @@ public class FollowController {
 	private final FollowService followService;
 
 	@PostMapping(
-		value = "/{follower}/profile/{followed}"
+		value = "/{follower}/profile/{followed}",
 		//produces = MediaType.TEXT_PLAIN_VALUE + ";charset=UTF-8"
 	)
 	public ResponseEntity<String> toggleFollow(@PathVariable Long follower, @PathVariable Long followed) {

--- a/src/main/java/com/goorm/clonestagram/like/domain/Like.java
+++ b/src/main/java/com/goorm/clonestagram/like/domain/Like.java
@@ -1,8 +1,10 @@
 package com.goorm.clonestagram.like.domain;
 
 import com.goorm.clonestagram.user.domain.Users;
+
 import jakarta.persistence.*;
 import lombok.*;
+
 import com.goorm.clonestagram.post.domain.Posts;
 
 import java.time.LocalDateTime;
@@ -13,34 +15,33 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "likes")
+@Table(name = "likes", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "post_id"}))
 public class Like {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private Users user;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private Users user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
-    private Posts post;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id", nullable = false)
+	private Posts post;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
 
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
 
-    public Like(Users user, Posts post) {
-        this.user = user;
-        this.post = post;
-        this.createdAt = LocalDateTime.now();
-    }
-
+	public Like(Users user, Posts post) {
+		this.user = user;
+		this.post = post;
+		this.createdAt = LocalDateTime.now();
+	}
 
 }

--- a/src/main/java/com/goorm/clonestagram/like/domain/Like.java~
+++ b/src/main/java/com/goorm/clonestagram/like/domain/Like.java~
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "likes")
+@Table(name = "likes", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "post_id"}))
 public class Like {
 
     @Id
@@ -41,5 +41,6 @@ public class Like {
         this.post = post;
         this.createdAt = LocalDateTime.now();
     }
+
 
 }

--- a/src/main/java/com/goorm/clonestagram/like/domain/LikeCount.java
+++ b/src/main/java/com/goorm/clonestagram/like/domain/LikeCount.java
@@ -1,0 +1,28 @@
+package com.goorm.clonestagram.like.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@RequiredArgsConstructor
+public class LikeCount {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	@NonNull
+	private Long postId;
+
+	@Column(nullable = false)
+	@NonNull
+	private Long likeCount;
+
+}

--- a/src/main/java/com/goorm/clonestagram/like/domain/LikeCount.java~
+++ b/src/main/java/com/goorm/clonestagram/like/domain/LikeCount.java~
@@ -1,0 +1,24 @@
+package com.goorm.clonestagram.like.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@RequiredArgsConstructor
+
+public class LikeCount {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private Long postId;
+
+	@Column(nullable = false)
+	private Long likeCount;
+
+}

--- a/src/main/java/com/goorm/clonestagram/like/repository/LikeRepository.java
+++ b/src/main/java/com/goorm/clonestagram/like/repository/LikeRepository.java
@@ -1,12 +1,16 @@
 package com.goorm.clonestagram.like.repository;
 
-import com.goorm.clonestagram.like.domain.Like;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goorm.clonestagram.like.domain.Like;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
@@ -17,4 +21,20 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 	Long countByPost_Id(Long postId); // 좋아요 개수 확인
 
 	Optional<Like> findByUser_IdAndPost_Id(Long userId, Long postsId);
+
+	@Query("SELECT lc.likeCount FROM LikeCount lc WHERE lc.postId = :postId")
+	Optional<Long> findLikeCount(@Param("postId") Long postId);
+
+	@Modifying
+	@Transactional
+	@Query("UPDATE LikeCount lc SET lc.likeCount = :count WHERE lc.postId = :postId")
+	void updateLikeCount(@Param("postId") Long postId, @Param("count") Long count);
+
+	@Query("SELECT COUNT(lc) > 0 FROM LikeCount lc WHERE lc.postId = :postId")
+	boolean existsLikeCountByPostId(@Param("postId") Long postId);
+
+	@Modifying
+	@Transactional
+	@Query("INSERT INTO LikeCount(postId, likeCount) VALUES (:postId, :likeCount)")
+	void saveLikeCount(@Param("postId") Long postId, @Param("likeCount") Long likeCount);
 }

--- a/src/main/java/com/goorm/clonestagram/like/repository/LikeRepository.java~
+++ b/src/main/java/com/goorm/clonestagram/like/repository/LikeRepository.java~
@@ -1,20 +1,36 @@
 package com.goorm.clonestagram.like.repository;
 
-import com.goorm.clonestagram.like.domain.Like;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goorm.clonestagram.like.domain.Like;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 	List<Like> findByPost_Id(Long postId); // 특정 게시물에 대한 좋아요 조회
 
-	Boolean existsByUserIdAndPost_Id(Long userId, Long postsId);
+	Boolean existsByUser_IdAndPost_Id(Long userId, Long postsId);
 
 	Long countByPost_Id(Long postId); // 좋아요 개수 확인
 
 	Optional<Like> findByUser_IdAndPost_Id(Long userId, Long postsId);
+
+	@Query("SELECT lc.likeCount FROM LikeCount lc WHERE lc.postId = :postId")
+	Optional<Long> findLikeCount(@Param("postId") Long postId);
+
+	@Modifying
+	@Transactional
+	@Query("UPDATE LikeCount lc SET lc.likeCount = :count WHERE lc.postId = :postId")
+	void updateLikeCount(@Param("postId") Long postId, @Param("count") Long count);
+
+	@Query("SELECT COUNT(lc) > 0 FROM LikeCount lc WHERE lc.postId = :postId")
+	boolean existsLikeCountByPostId(@Param("postId") Long postId);
+
 }

--- a/src/main/java/com/goorm/clonestagram/like/service/LikeService.java~
+++ b/src/main/java/com/goorm/clonestagram/like/service/LikeService.java~
@@ -1,6 +1,7 @@
 package com.goorm.clonestagram.like.service;
 
 import com.goorm.clonestagram.exception.PostNotFoundException;
+import com.goorm.clonestagram.like.domain.LikeCount;
 import com.goorm.clonestagram.post.domain.Posts;
 import com.goorm.clonestagram.like.domain.Like;
 import com.goorm.clonestagram.like.repository.LikeRepository;
@@ -39,10 +40,23 @@ public class LikeService {
 				likeRepository.save(new Like(user, post)); // 좋아요 추가
 			} catch (DataIntegrityViolationException e) {
 				// 동시에 두 요청이 온 경우 하나는 성공하고 하나는 이곳으로 옴.
-				if (likeRepository.findByUser_IdAndPost_Id(userId, postId).isEmpty()) {
-					likeRepository.save(new Like(user, post));
+				if (likeRepository.existsByUser_IdAndPost_Id(userId, postId)) {
+					throw e;
 				}
 			}
+		}
+
+		syncLikeCount(postId);
+	}
+
+	@Transactional
+	public void syncLikeCount(Long postId) {
+		Long count = likeRepository.countByPost_Id(postId);
+
+		if (likeRepository.existsLikeCountByPostId(postId)) {
+			likeRepository.updateLikeCount(postId, count);
+		} else {
+			likeRepository.saveLikeCount(postId, count);
 		}
 	}
 
@@ -51,7 +65,9 @@ public class LikeService {
 		if (!postService.existsByIdAndDeletedIsFalse(postId)) {
 			throw new PostNotFoundException(postId);
 		}
-		return likeRepository.countByPost_Id(postId);
+
+		// return likeRepository.countByPost_Id(postId);
+		return likeRepository.findLikeCount(postId).orElse(0L);
 	}
 
 	public boolean isPostLikedByLoginUser(Long postId, Long userId) {

--- a/src/main/java/com/goorm/clonestagram/like/service/LikeService.java~
+++ b/src/main/java/com/goorm/clonestagram/like/service/LikeService.java~
@@ -10,6 +10,7 @@ import com.goorm.clonestagram.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,10 +35,14 @@ public class LikeService {
 		if (existingLike.isPresent()) {
 			likeRepository.delete(existingLike.get()); // 좋아요 취소
 		} else {
-			Like like = new Like();
-			like.setUser(user);
-			like.setPost(post);
-			likeRepository.save(like); // 좋아요 추가
+			try {
+				likeRepository.save(new Like(user, post)); // 좋아요 추가
+			} catch (DataIntegrityViolationException e) {
+				// 동시에 두 요청이 온 경우 하나는 성공하고 하나는 이곳으로 옴.
+				if (likeRepository.findByUser_IdAndPost_Id(userId, postId).isEmpty()) {
+					likeRepository.save(new Like(user, post));
+				}
+			}
 		}
 	}
 
@@ -53,7 +58,7 @@ public class LikeService {
 		Users user = userService.findByIdAndDeletedIsFalse(userId);
 		Posts post = postService.findByIdAndDeletedIsFalse(postId);
 
-		return likeRepository.existsByUser_IdAndPost_Id(userId, postId);
+		return likeRepository.existsByUser_IdAndPost_Id(user.getId(), post.getId());
 	}
 
 }

--- a/src/test/java/com/goorm/clonestagram/like/service/LikeServiceIntegrationTest.java
+++ b/src/test/java/com/goorm/clonestagram/like/service/LikeServiceIntegrationTest.java
@@ -117,44 +117,44 @@ public class LikeServiceIntegrationTest {
 		assertEquals(2L, likeService.getLikeCount(post.getId()), "좋아요 개수가 2이어야 합니다.");
 	}
 
-	@Test
-	public void testToggleLikeTwiceRapidly() throws InterruptedException {
-		// Todo
-		// Users user = new Users();
-		// user.setUsername("testUser");
-		// user.setEmail("test@example.com");
-		// user.setPassword("password");
-		// user.setDeleted(false);
-		// user = userRepository.save(user);
-		//
-		// Posts post = new Posts();
-		// post.setUser(user);
-		// post.setContent("Test Post");
-		// post.setContentType(IMAGE);  // contents_type 추가
-		// post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
-		// post.setDeleted(false);
-		// post = postsRepository.save(post);
-		//
-		// Long userId = user.getId();
-		// Long postId = post.getId();
-		//
-		// int threadCount = 1;
-		// ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-		// CountDownLatch latch = new CountDownLatch(threadCount);
-		//
-		// for (int i = 0; i < threadCount; i++) {
-		// 	executor.submit(() -> {
-		// 		try {
-		// 			likeService.toggleLike(userId, postId);
-		// 		} finally {
-		// 			latch.countDown();
-		// 		}
-		// 	});
-		// }
-		//
-		// latch.await(); // 모든 쓰레드 종료 대기
-		//
-		// boolean liked = likeService.isPostLikedByLoginUser(userId, postId);
-		// System.out.println("최종 좋아요 상태: " + liked);
-	}
+	// @Test
+	// public void testToggleLikeTwiceRapidly() throws InterruptedException {
+	// Todo
+	// Users user = new Users();
+	// user.setUsername("testUser");
+	// user.setEmail("test@example.com");
+	// user.setPassword("password");
+	// user.setDeleted(false);
+	// user = userRepository.save(user);
+	//
+	// Posts post = new Posts();
+	// post.setUser(user);
+	// post.setContent("Test Post");
+	// post.setContentType(IMAGE);  // contents_type 추가
+	// post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
+	// post.setDeleted(false);
+	// post = postsRepository.save(post);
+	//
+	// Long userId = user.getId();
+	// Long postId = post.getId();
+	//
+	// int threadCount = 1;
+	// ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+	// CountDownLatch latch = new CountDownLatch(threadCount);
+	//
+	// for (int i = 0; i < threadCount; i++) {
+	// 	executor.submit(() -> {
+	// 		try {
+	// 			likeService.toggleLike(userId, postId);
+	// 		} finally {
+	// 			latch.countDown();
+	// 		}
+	// 	});
+	// }
+	//
+	// latch.await(); // 모든 쓰레드 종료 대기
+	//
+	// boolean liked = likeService.isPostLikedByLoginUser(userId, postId);
+	// System.out.println("최종 좋아요 상태: " + liked);
+	// }
 }

--- a/src/test/java/com/goorm/clonestagram/like/service/LikeServiceIntegrationTest.java~
+++ b/src/test/java/com/goorm/clonestagram/like/service/LikeServiceIntegrationTest.java~
@@ -119,42 +119,41 @@ public class LikeServiceIntegrationTest {
 
 	@Test
 	public void testToggleLikeTwiceRapidly() throws InterruptedException {
-		// Todo
-		// Users user = new Users();
-		// user.setUsername("testUser");
-		// user.setEmail("test@example.com");
-		// user.setPassword("password");
-		// user.setDeleted(false);
-		// user = userRepository.save(user);
-		//
-		// Posts post = new Posts();
-		// post.setUser(user);
-		// post.setContent("Test Post");
-		// post.setContentType(IMAGE);  // contents_type 추가
-		// post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
-		// post.setDeleted(false);
-		// post = postsRepository.save(post);
-		//
-		// Long userId = user.getId();
-		// Long postId = post.getId();
-		//
-		// int threadCount = 1;
-		// ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-		// CountDownLatch latch = new CountDownLatch(threadCount);
-		//
-		// for (int i = 0; i < threadCount; i++) {
-		// 	executor.submit(() -> {
-		// 		try {
-		// 			likeService.toggleLike(userId, postId);
-		// 		} finally {
-		// 			latch.countDown();
-		// 		}
-		// 	});
-		// }
-		//
-		// latch.await(); // 모든 쓰레드 종료 대기
-		//
-		// boolean liked = likeService.isPostLikedByLoginUser(userId, postId);
-		// System.out.println("최종 좋아요 상태: " + liked);
+		Users user = new Users();
+		user.setUsername("testUser");
+		user.setEmail("test@example.com");
+		user.setPassword("password");
+		user.setDeleted(false);
+		user = userRepository.save(user);
+
+		Posts post = new Posts();
+		post.setUser(user);
+		post.setContent("Test Post");
+		post.setContentType(IMAGE);  // contents_type 추가
+		post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
+		post.setDeleted(false);
+		post = postsRepository.save(post);
+
+		Long userId = user.getId();
+		Long postId = post.getId();
+
+		int threadCount = 1;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		for (int i = 0; i < threadCount; i++) {
+			executor.submit(() -> {
+				try {
+					likeService.toggleLike(userId, postId);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await(); // 모든 쓰레드 종료 대기
+
+		boolean liked = likeService.isPostLikedByLoginUser(userId, postId);
+		System.out.println("최종 좋아요 상태: " + liked);
 	}
 }

--- a/src/test/java/com/goorm/clonestagram/like/service/LikeServiceIntegrationTest.java~
+++ b/src/test/java/com/goorm/clonestagram/like/service/LikeServiceIntegrationTest.java~
@@ -117,43 +117,44 @@ public class LikeServiceIntegrationTest {
 		assertEquals(2L, likeService.getLikeCount(post.getId()), "좋아요 개수가 2이어야 합니다.");
 	}
 
-	@Test
-	public void testToggleLikeTwiceRapidly() throws InterruptedException {
-		Users user = new Users();
-		user.setUsername("testUser");
-		user.setEmail("test@example.com");
-		user.setPassword("password");
-		user.setDeleted(false);
-		user = userRepository.save(user);
-
-		Posts post = new Posts();
-		post.setUser(user);
-		post.setContent("Test Post");
-		post.setContentType(IMAGE);  // contents_type 추가
-		post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
-		post.setDeleted(false);
-		post = postsRepository.save(post);
-
-		Long userId = user.getId();
-		Long postId = post.getId();
-
-		int threadCount = 1;
-		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-		CountDownLatch latch = new CountDownLatch(threadCount);
-
-		for (int i = 0; i < threadCount; i++) {
-			executor.submit(() -> {
-				try {
-					likeService.toggleLike(userId, postId);
-				} finally {
-					latch.countDown();
-				}
-			});
-		}
-
-		latch.await(); // 모든 쓰레드 종료 대기
-
-		boolean liked = likeService.isPostLikedByLoginUser(userId, postId);
-		System.out.println("최종 좋아요 상태: " + liked);
-	}
+	// @Test
+	// public void testToggleLikeTwiceRapidly() throws InterruptedException {
+		// Todo
+		// Users user = new Users();
+		// user.setUsername("testUser");
+		// user.setEmail("test@example.com");
+		// user.setPassword("password");
+		// user.setDeleted(false);
+		// user = userRepository.save(user);
+		//
+		// Posts post = new Posts();
+		// post.setUser(user);
+		// post.setContent("Test Post");
+		// post.setContentType(IMAGE);  // contents_type 추가
+		// post.setMediaName("test-url");   // media_url 추가 (nullable=false일 경우)
+		// post.setDeleted(false);
+		// post = postsRepository.save(post);
+		//
+		// Long userId = user.getId();
+		// Long postId = post.getId();
+		//
+		// int threadCount = 1;
+		// ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		// CountDownLatch latch = new CountDownLatch(threadCount);
+		//
+		// for (int i = 0; i < threadCount; i++) {
+		// 	executor.submit(() -> {
+		// 		try {
+		// 			likeService.toggleLike(userId, postId);
+		// 		} finally {
+		// 			latch.countDown();
+		// 		}
+		// 	});
+		// }
+		//
+		// latch.await(); // 모든 쓰레드 종료 대기
+		//
+		// boolean liked = likeService.isPostLikedByLoginUser(userId, postId);
+		// System.out.println("최종 좋아요 상태: " + liked);
+	// }
 }

--- a/src/test/java/com/goorm/clonestagram/like/service/LikeServiceTest.java~
+++ b/src/test/java/com/goorm/clonestagram/like/service/LikeServiceTest.java~
@@ -112,7 +112,7 @@ public class LikeServiceTest {
 
 		// then
 		assertThat(result).isEqualTo(3L);
-		verify(likeRepository, times(1)).findLikeCount(postId);
+		verify(likeRepository, times(1)).countByPost_Id(postId);
 	}
 
 	@Test


### PR DESCRIPTION
좋아요-카운트 테이블 추가. ID(PK), PostId(FK), LikeCount(Long) 속성을 가짐
좋아요를 갱신(추가or삭제)할때마다 좋아요 테이블에서 해당 포스트ID의 좋아요 갯수를 조회하여 좋아요-카운트 테이블에 반영.
좋아요의 갯수가 필요할 때 좋아요-카운트 테이블의 값을 불러온다.

<특이사항>

![스크린샷 2025-04-10 004630](https://github.com/user-attachments/assets/c2d64a27-22aa-4bf6-909e-19996735680f)
![스크린샷 2025-04-10 004633](https://github.com/user-attachments/assets/b5cf1618-7cc4-43f3-b861-aca508ae3c83)

push 전에 테스트 전부 돌리는 과정에서 follow쪽 에러 발생.
utf-8이 적용 안돼서 폰트가 깨진것으로 보입니다.